### PR TITLE
🎨 Palette: Improve custom deck remove button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-07-07 - Replace interactive spans with button elements
+**Learning:** Found an accessibility issue pattern in the custom deck configuration where a simulated button (a `<span>` with an `onclick` handler) was used to remove cards. Spans lack native semantic meaning for screen readers, aren't keyboard focusable by default, and miss out on native keyboard activation (Enter/Space).
+**Action:** Replaced the `<span>` with a proper `<button>` element. I also removed default button styles (background, border) in CSS to maintain the visual design, and added a `:focus-visible` state outline to provide clear visual feedback for keyboard users. Always use semantic `<button>` elements for interactive click targets.

--- a/script.js
+++ b/script.js
@@ -797,9 +797,10 @@ function renderCustomDeckList() {
         cardText.className = card.color;
         cardText.textContent = card.display;
 
-        const removeBtn = document.createElement('span');
+        const removeBtn = document.createElement('button');
         removeBtn.className = 'remove-custom-card';
         removeBtn.textContent = '×';
+        removeBtn.setAttribute('aria-label', `Remove ${getRankName(card.rank)} of ${card.suitName}`);
         removeBtn.onclick = () => removeCustomCard(index);
 
         item.appendChild(cardText);

--- a/style.css
+++ b/style.css
@@ -692,8 +692,24 @@ footer {
 }
 
 .remove-custom-card {
+    background: none;
+    border: none;
+    padding: 0;
     cursor: pointer;
     color: #ff4444;
     font-weight: bold;
     margin-left: 5px;
+    font-size: 1.2rem;
+    line-height: 1;
+    transition: opacity 0.2s;
+}
+
+.remove-custom-card:hover {
+    opacity: 0.8;
+}
+
+.remove-custom-card:focus-visible {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+    border-radius: 2px;
 }


### PR DESCRIPTION
💡 **What**: Replaced the simulated interactive `<span>` elements used to remove cards from the custom deck with semantic `<button>` elements. Added a dynamic `aria-label` to each button, and improved visual feedback with `:hover` and `:focus-visible` styles.

🎯 **Why**: Using a `<span>` with an `onclick` handler is an accessibility anti-pattern. Screen readers don't natively recognize them as interactive controls, and keyboard users cannot navigate to them via the `Tab` key or activate them using `Enter` or `Space`. By upgrading to a semantic `<button>`, the interaction works properly for all users. The addition of the dynamic `aria-label` (e.g. "Remove Ace of Spades") ensures screen reader users understand exactly what the button does instead of hearing "times". The new focus outlines make keyboard navigation visually apparent.

📸 **Before/After**: The visual design remains identical by default, but now displays a clean white outline when focused via keyboard.

♿ **Accessibility**: 
- Native keyboard focus (`Tab` navigation)
- Native keyboard interaction (`Enter`/`Space` activation)
- Screen reader semantic role (Button)
- Descriptive, dynamic accessible names (`aria-label`)
- High contrast focus indicators (`:focus-visible`)

---
*PR created automatically by Jules for task [6601277217092880297](https://jules.google.com/task/6601277217092880297) started by @noerarief23*