### PR TITLE
🎨 Palette: Add Empty State to Card History and form A11y enhancements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-07-07 - Replace interactive spans with button elements
 **Learning:** Found an accessibility issue pattern in the custom deck configuration where a simulated button (a `<span>` with an `onclick` handler) was used to remove cards. Spans lack native semantic meaning for screen readers, aren't keyboard focusable by default, and miss out on native keyboard activation (Enter/Space).
 **Action:** Replaced the `<span>` with a proper `<button>` element. I also removed default button styles (background, border) in CSS to maintain the visual design, and added a `:focus-visible` state outline to provide clear visual feedback for keyboard users. Always use semantic `<button>` elements for interactive click targets.
+
+## 2025-07-08 - Add Empty States for Better UX
+**Learning:** Empty lists (like the card history) can leave users wondering what should be there. Providing a clear "empty state" with helpful text ("No cards drawn yet") guides the user and provides better initial context. Similarly, implicit inputs without clear screen-reader labels can cause confusion.
+**Action:** Always include empty states for dynamic lists and explicit `aria-label` or `for` attributes on inputs and labels.

--- a/index.html
+++ b/index.html
@@ -38,7 +38,9 @@
             <!-- Card History -->
             <aside class="history-panel">
                 <h3>Card History</h3>
-                <div id="cardHistory" class="card-history-list"></div>
+                <div id="cardHistory" class="card-history-list">
+                    <div class="empty-state">No cards drawn yet</div>
+                </div>
                 <div class="stats">
                     <p>Remaining: <span id="remainingCount">52</span></p>
                     <p>Drawn: <span id="drawnCount">0</span></p>
@@ -57,11 +59,11 @@
                     <option value="custom">Custom</option>
                     <option value="custom-list">Custom List</option>
                 </select>
-                <input type="number" id="customCardCount" class="hidden" min="1" max="52" value="10">
+                <input type="number" id="customCardCount" class="hidden" min="1" max="52" value="10" aria-label="Custom number of cards to draw">
             </div>
 
             <div id="customDeckContainer" class="config-item custom-deck-container hidden">
-                <label>Custom Deck Cards:</label>
+                <label for="customDeckSelect">Custom Deck Cards:</label>
                 <div class="custom-deck-controls">
                     <select id="customDeckSelect">
                         <option value="">-- Select a card to add --</option>

--- a/script.js
+++ b/script.js
@@ -659,6 +659,12 @@ function addToHistory(card) {
     historyItem.appendChild(cardDisplay);
     historyItem.appendChild(cardName);
     
+    // Remove empty state if it exists
+    const emptyState = cardHistoryDiv.querySelector('.empty-state');
+    if (emptyState) {
+        emptyState.remove();
+    }
+
     // Add at the top
     cardHistoryDiv.insertBefore(historyItem, cardHistoryDiv.firstChild);
 }
@@ -733,7 +739,7 @@ function resetGame() {
     currentCard = null;
     
     // Clear history
-    cardHistoryDiv.innerHTML = '';
+    cardHistoryDiv.innerHTML = '<div class="empty-state">No cards drawn yet</div>';
     
     // Update stats
     updateStats();

--- a/style.css
+++ b/style.css
@@ -352,6 +352,18 @@ main {
     min-height: 200px;
 }
 
+.empty-state {
+    color: #666666;
+    font-style: italic;
+    text-align: center;
+    padding: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    min-height: 100px;
+}
+
 .history-item {
     background: #000000;
     border: 1px solid #333333;


### PR DESCRIPTION
💡 What: Added an explicit "No cards drawn yet" empty state message to the card history view, and improved screen reader accessibility for form inputs.

🎯 Why: To improve the initial user experience by providing clear feedback about empty lists, and ensure custom deck inputs have correct ARIA labels for accessibility.

📸 Before/After: The Card History panel now displays a helpful message when empty, rather than just being a dark blank square.

♿ Accessibility: Added `aria-label` to the custom card count input, and a `for` attribute to link the custom deck cards label with its select element.

---
*PR created automatically by Jules for task [16089061318171639796](https://jules.google.com/task/16089061318171639796) started by @noerarief23*