### PR TITLE
🎨 Palette: Add keyboard focus styles and form labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-07-07 - Replace interactive spans with button elements
 **Learning:** Found an accessibility issue pattern in the custom deck configuration where a simulated button (a `<span>` with an `onclick` handler) was used to remove cards. Spans lack native semantic meaning for screen readers, aren't keyboard focusable by default, and miss out on native keyboard activation (Enter/Space).
 **Action:** Replaced the `<span>` with a proper `<button>` element. I also removed default button styles (background, border) in CSS to maintain the visual design, and added a `:focus-visible` state outline to provide clear visual feedback for keyboard users. Always use semantic `<button>` elements for interactive click targets.
+
+## 2026-07-09 - Global focus-visible styles and dynamically revealed inputs
+**Learning:** Discovered an accessibility issue pattern where inputs that become visible dynamically (like the custom card count input) often lack implicit ARIA labels because they aren't part of the static layout's labeling scheme. Also noticed that relying on component-specific focus styles led to missing focus indicators for general interactive elements like buttons and dropdowns.
+**Action:** Applied a global `:focus-visible` style in CSS to handle basic keyboard focus across all interactive elements (`button`, `select`, `input`) instead of targeting them individually. I will also ensure dynamically revealed inputs get proper `aria-label` attributes if they lack a visible `<label>`.

--- a/index.html
+++ b/index.html
@@ -57,11 +57,11 @@
                     <option value="custom">Custom</option>
                     <option value="custom-list">Custom List</option>
                 </select>
-                <input type="number" id="customCardCount" class="hidden" min="1" max="52" value="10">
+                <input type="number" id="customCardCount" class="hidden" min="1" max="52" value="10" aria-label="Number of custom cards">
             </div>
 
             <div id="customDeckContainer" class="config-item custom-deck-container hidden">
-                <label>Custom Deck Cards:</label>
+                <label for="customDeckSelect">Custom Deck Cards:</label>
                 <div class="custom-deck-controls">
                     <select id="customDeckSelect">
                         <option value="">-- Select a card to add --</option>

--- a/style.css
+++ b/style.css
@@ -4,6 +4,14 @@
     box-sizing: border-box;
 }
 
+button:focus-visible,
+select:focus-visible,
+input:focus-visible {
+    outline: 2px solid #ffffff;
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background: #000000;


### PR DESCRIPTION
💡 What:
- Added a `for="customDeckSelect"` attribute to the "Custom Deck Cards" label.
- Added an `aria-label="Number of custom cards"` to the custom card count number input.
- Added a global `:focus-visible` style for `button`, `select`, and `input` elements in `style.css`.
- Updated `.Jules/palette.md` with UX/a11y learnings regarding dynamically revealed inputs and global focus styles.

🎯 Why:
- The "Custom Deck Cards" select lacked a programmatic label.
- The custom card count input becomes visible dynamically but doesn't have a visible label, making it confusing for screen reader users.
- Most interactive elements (like the Spin button, Reset button, and dropdowns) lacked visual feedback when navigating via keyboard, making it difficult for keyboard users to track focus.

📸 Before/After:
Before: Forms lacked labels in screen readers, and pressing Tab across the page did not show a clear focus ring on main elements.
After: Focus states are visible with a white outline when navigating via keyboard, and forms are fully accessible to screen readers.

♿ Accessibility:
- Improves screen reader support for form controls via `for` and `aria-label`.
- Improves keyboard navigation support via global `:focus-visible` outline styles.

---
*PR created automatically by Jules for task [9346009769283693245](https://jules.google.com/task/9346009769283693245) started by @noerarief23*