### PR TITLE
⚡ Bolt: Debounce canvas resize and add GPU compositing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-01 - Debouncing Canvas Resize and GPU Compositing
+**Learning:** Frequent window resize events trigger continuous and expensive canvas redraws (especially with text shadows and loop iterations), causing main thread blockages. Hardware-accelerated CSS transforms (`transform: rotate`) without `will-change: transform` can also lead to paint thrashing during spin animations if the element isn't promoted to a compositor layer.
+**Action:** Always debounce window resize events that trigger heavy calculations (like canvas redraws) using a short timeout (e.g., 150ms). Use `will-change: transform` on elements that undergo continuous CSS transform animations to ensure GPU compositing and smooth 60fps rendering without blocking the main thread.

--- a/script.js
+++ b/script.js
@@ -766,7 +766,12 @@ function resizeCanvas() {
 }
 
 // Initialize
-window.addEventListener('resize', resizeCanvas);
+// Optimize: Debounce window resize to prevent excessive redraws (performance)
+let resizeTimeout;
+window.addEventListener('resize', () => {
+    clearTimeout(resizeTimeout);
+    resizeTimeout = setTimeout(resizeCanvas, 150);
+});
 
 // Wait for DOM and layout to be ready
 function waitForLayout(callback) {

--- a/style.css
+++ b/style.css
@@ -175,6 +175,7 @@ main {
     max-width: 100%;
     max-height: 100%;
     display: block;
+    will-change: transform; /* GPU compositing for smoother spin animations */
 }
 
 .wheel-pointer {


### PR DESCRIPTION
### 💡 What
- Added a 150ms debounce to the `window.resize` event listener in `script.js`.
- Added `will-change: transform;` to the `.wheel-container #wheelCanvas` selector in `style.css`.
- Documented performance learnings in `.jules/bolt.md`.

### 🎯 Why
- The `window.resize` event fires continuously during resizing, triggering `resizeCanvas()` and `drawWheel()` constantly. Because drawing the canvas is computationally expensive (iterating up to 52 times and rendering text with `shadowBlur`), this caused main thread blockage and significant jank.
- Hardware-accelerated CSS transforms (`transform: rotate`) can lead to paint thrashing during continuous animations if the element is not promoted to its own compositor layer. `will-change: transform` fixes this.

### 📊 Impact
- Reduces main-thread blocking during browser window resizes by limiting canvas recalculations to once per 150ms after the resize completes.
- Provides a smoother 60fps spin animation by offloading rendering to the GPU and preventing paint thrashing.

### 🔬 Measurement
- Resize the browser window rapidly—the canvas will now wait to recalculate until the resizing has paused for 150ms, drastically reducing CPU spikes in the Performance profiler.
- Observe smoother rotation animations via Chrome DevTools rendering tab by verifying that the canvas is placed on a separate layer (Layer borders) and there are fewer paint operations during the spin.

---
*PR created automatically by Jules for task [16457455082779818340](https://jules.google.com/task/16457455082779818340) started by @noerarief23*