### PR TITLE
🎨 Palette: Add Spacebar Shortcut to Spin Wheel

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2025-07-08 - Add Empty States for Better UX
 **Learning:** Empty lists (like the card history) can leave users wondering what should be there. Providing a clear "empty state" with helpful text ("No cards drawn yet") guides the user and provides better initial context. Similarly, implicit inputs without clear screen-reader labels can cause confusion.
 **Action:** Always include empty states for dynamic lists and explicit `aria-label` or `for` attributes on inputs and labels.
+## 2023-11-20 - Dark Mode Focus Visibility
+**Learning:** Default browser focus rings often fail contrast requirements on dark backgrounds (#000000). Keyboard users may lose their place without custom, high-contrast `:focus-visible` styles.
+**Action:** Always verify keyboard navigation in dark themes and apply a high-contrast focus ring (e.g., `#00BCD4` on black) using `:focus-visible`.

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
                             <span class="button-text">SPIN</span>
                             <span class="button-glow"></span>
                         </button>
+                        <div class="keyboard-hint" aria-hidden="true">Press <kbd>Space</kbd> to spin</div>
                     </div>
                 </div>
             </main>

--- a/script.js
+++ b/script.js
@@ -723,6 +723,33 @@ renderCustomDeckList();
 spinButton.addEventListener('click', () => {
     spin();
 });
+
+// Spacebar shortcut for spinning
+document.addEventListener('keydown', (e) => {
+    // Only trigger if spacebar is pressed
+    if (e.code === 'Space') {
+        // Prevent default scrolling behavior
+
+        // Don't trigger if user is interacting with form elements
+        const activeElement = document.activeElement;
+        const ignoreElements = ['INPUT', 'SELECT', 'TEXTAREA', 'BUTTON'];
+
+        if (activeElement && ignoreElements.includes(activeElement.tagName)) {
+            return; // Let the native element handle the spacebar
+        }
+
+        e.preventDefault();
+
+        // Trigger spin if not already spinning and button is not disabled
+        if (!isSpinning && !spinButton.disabled) {
+            spin();
+            // Provide visual feedback
+            spinButton.classList.add('active');
+            setTimeout(() => spinButton.classList.remove('active'), 150);
+        }
+    }
+});
+
 resetButton.addEventListener('click', resetGame);
 cardCountSelect.addEventListener('change', handleCardCountChange);
 customCardCountInput.addEventListener('change', resetGame);

--- a/style.css
+++ b/style.css
@@ -306,8 +306,10 @@ main {
     background: #cccccc;
 }
 
-.spin-button:active {
+.spin-button:active,
+.spin-button.active {
     transform: scale(0.95);
+    background: #cccccc;
 }
 
 .spin-button:disabled {
@@ -723,4 +725,30 @@ footer {
     outline: 2px solid #ffffff;
     outline-offset: 2px;
     border-radius: 2px;
+}
+
+/* Global Focus Visible for Keyboard Navigation */
+:focus-visible {
+    outline: 2px solid #00BCD4;
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
+/* Keyboard Shortcut Hint */
+.keyboard-hint {
+    color: #666666;
+    font-size: 0.85rem;
+    margin-top: 8px;
+    text-align: center;
+}
+
+.keyboard-hint kbd {
+    background: #333333;
+    border: 1px solid #555555;
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-size: 0.8rem;
+    font-family: inherit;
+    color: #cccccc;
+    box-shadow: 0 2px 0 #222222;
 }


### PR DESCRIPTION
💡 What: Added a global keyboard shortcut allowing users to trigger the spin wheel by pressing the Spacebar, along with a visual hint.
🎯 Why: Improves the overall interaction experience and accessibility for keyboard users, making the game feel more responsive.
📸 Before/After: Visual changes include a new hint reading "Press Space to spin" right below the spin button, and high-contrast `#00BCD4` focus rings for keyboard navigation.
♿ Accessibility: Ensures that pressing Space only triggers the wheel when no interactive form elements (inputs, buttons, selects) are focused. We also added global `:focus-visible` styles to resolve low contrast default focus rings against the dark background.

---
*PR created automatically by Jules for task [3147201185215402125](https://jules.google.com/task/3147201185215402125) started by @noerarief23*