### PR TITLE
⚡ Bolt: Preload result assets to eliminate display latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-03-01 - Debouncing Canvas Resize and GPU Compositing
 **Learning:** Frequent window resize events trigger continuous and expensive canvas redraws (especially with text shadows and loop iterations), causing main thread blockages. Hardware-accelerated CSS transforms (`transform: rotate`) without `will-change: transform` can also lead to paint thrashing during spin animations if the element isn't promoted to a compositor layer.
 **Action:** Always debounce window resize events that trigger heavy calculations (like canvas redraws) using a short timeout (e.g., 150ms). Use `will-change: transform` on elements that undergo continuous CSS transform animations to ensure GPU compositing and smooth 60fps rendering without blocking the main thread.
+## 2026-07-13 - Preloading Assets During Long Animation
+**Learning:** During long, CSS-driven animations or multi-second timeouts (like the 5-8 second wheel spin), you can pre-calculate the visual result using the deterministic mathematical state to fetch remote network assets ahead of time, eliminating visual pop-in when the UI is finally updated.
+**Action:** When working on animated web games with deterministic outcomes, identify the earliest moment the result can be calculated, and proactively `new Image().src` or fetch resources during the animation gap instead of waiting for the render function to fire.

--- a/script.js
+++ b/script.js
@@ -69,6 +69,7 @@ const MAX_RETRIES = 3;
 
 // Audio for sound effects
 let spinningAudio = null;
+let resultAudio = null; // ⚡ Bolt: Cache result audio instance
 
 // Preload audio files
 function preloadAudio() {
@@ -81,6 +82,12 @@ function preloadAudio() {
     // Handle audio load error
     spinningAudio.addEventListener('error', () => {
         console.warn('Drum roll audio file not found. Please add drumroll.mp3 to your project folder.');
+    });
+
+    // ⚡ Bolt: Preload result sound to avoid disk I/O and garbage collection during critical render path
+    resultAudio = new Audio('./result.mp3');
+    resultAudio.addEventListener('error', () => {
+        console.warn('Result audio file not found.');
     });
 }
 
@@ -111,10 +118,17 @@ function stopSpinningSound() {
 // Play result/win sound effect
 function playResultSound() {
     try {
-        const winAudio = new Audio('./result.mp3');
-        winAudio.currentTime = 1;
-        winAudio.volume = 0.5;
-        winAudio.play().catch(err => console.error('Error playing result sound:', err));
+        // ⚡ Bolt: Use cached audio instance instead of instantiating new Audio() on every win to eliminate latency
+        if (resultAudio) {
+            resultAudio.currentTime = 1;
+            resultAudio.volume = 0.5;
+            resultAudio.play().catch(err => console.error('Error playing result sound:', err));
+        } else {
+            const winAudio = new Audio('./result.mp3');
+            winAudio.currentTime = 1;
+            winAudio.volume = 0.5;
+            winAudio.play().catch(err => console.error('Error playing result sound:', err));
+        }
     } catch (error) {
         console.error('Error playing result sound:', error);
     }
@@ -324,6 +338,20 @@ function spin(isRetry = false) {
     // Random final position
     const randomAngle = Math.random() * 2 * Math.PI;
     const finalRotation = rotation + totalRotation + randomAngle;
+
+    // ⚡ Bolt: Precalculate winning card and preload its image while spin animation plays
+    // Determine the predicted winning card by calculating where the pointer will end up
+    let predictedRotation = ((finalRotation % (2 * Math.PI)) + (2 * Math.PI)) % (2 * Math.PI);
+    let predictedPointerAngle = (2 * Math.PI - predictedRotation - Math.PI / 2) % (2 * Math.PI);
+    if (predictedPointerAngle < 0) predictedPointerAngle += 2 * Math.PI;
+    const segmentAngle = (2 * Math.PI) / availableCards.length;
+    const predictedWinningIndex = Math.floor(predictedPointerAngle / segmentAngle) % availableCards.length;
+    const predictedCard = availableCards[predictedWinningIndex];
+    if (predictedCard) {
+        // Preload image over network during 5-8s spin animation to eliminate visual pop-in when showResult() runs
+        const img = new Image();
+        img.src = `cards/${RANK_MAP[predictedCard.rank]}_of_${SUIT_MAP[predictedCard.suitName]}.svg`;
+    }
 
     // Animation duration (5-8 seconds)
     const duration = 5000 + Math.random() * 3000;


### PR DESCRIPTION
💡 What: Cached the result audio instance and precalculated the winning card during the spin animation to eagerly fetch the corresponding SVG image over the network before the animation completes.

🎯 Why: To eliminate visual pop-in and audio latency that occurs when instantiating new Audio() objects and loading images from the network at the exact moment the result card UI is mounted. By shifting this work to the 5-8 seconds of idle time while the wheel spins, the final render feels instantaneous.

📊 Impact: Reduces instantiation latency for audio and eliminates up to several hundred milliseconds of network latency/visual layout shift when the winning card appears.

🔬 Measurement: Visual inspection of the UI, noting the elimination of the blank card frame flash. Verifiable by using Chrome DevTools network tab (throttled to 3G) and observing the image load during the spin rather than at the end.

---
*PR created automatically by Jules for task [17924365788381569514](https://jules.google.com/task/17924365788381569514) started by @noerarief23*