### PR TITLE
🎨 Palette: Add inline confirmation for destructive reset action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2023-11-20 - Replace blocking alerts with inline feedback
 **Learning:** Using blocking browser `alert()` popups for simple form validation interrupts the user experience, shifts focus abruptly, and creates jarring interactions. In single-page applications, users expect fluid, contextual feedback. Additionally, allowing a form submission to proceed when it's known to be invalid (then blocking it) is an anti-pattern.
 **Action:** Use inline text changes on buttons (combined with `aria-live` regions for screen readers) to provide contextual, non-blocking feedback. Additionally, use the `:disabled` state to prevent invalid submissions entirely, visually guiding the user.
+
+## 2024-03-24 - Inline Destructive Action Confirmation
+**Learning:** For destructive actions (like clearing game state), using non-blocking inline state changes (e.g. changing text to "Confirm?" and utilizing aria-live) prevents accidental data loss without breaking user flow or triggering intrusive native confirm() dialogs.
+**Action:** Implement similar 2-step click patterns for reset/delete actions where screen real-estate is limited and native dialogs are undesirable.

--- a/script.js
+++ b/script.js
@@ -857,6 +857,56 @@ spinButton.addEventListener('click', () => {
     spin();
 });
 
+// Inline confirmation for destructive reset action
+let resetConfirmTimeout;
+function handleResetClick(e) {
+    // Store original markup and text if not already stored
+    if (!resetButton.dataset.originalHtml) {
+        resetButton.dataset.originalHtml = resetButton.innerHTML;
+    }
+    const hasOriginalAriaLabel = resetButton.dataset.hasOriginalAriaLabel === 'true' || resetButton.hasAttribute('aria-label');
+    resetButton.dataset.hasOriginalAriaLabel = hasOriginalAriaLabel.toString();
+
+    if (hasOriginalAriaLabel && !resetButton.dataset.originalAriaLabel) {
+        resetButton.dataset.originalAriaLabel = resetButton.getAttribute('aria-label');
+    }
+
+    if (resetButton.dataset.confirming === 'true') {
+        // Second click - execute reset
+        clearTimeout(resetConfirmTimeout);
+        resetButton.dataset.confirming = 'false';
+        resetButton.innerHTML = resetButton.dataset.originalHtml;
+        if (hasOriginalAriaLabel) {
+            resetButton.setAttribute('aria-label', resetButton.dataset.originalAriaLabel);
+        } else {
+            resetButton.removeAttribute('aria-label');
+        }
+        resetGame();
+    } else {
+        // First click - ask for confirmation using showFeedback helper style approach
+        // to avoid custom inline CSS
+        resetButton.dataset.confirming = 'true';
+        resetButton.innerHTML = '⚠️ Confirm Reset?';
+
+        // Ensure screen readers announce this change
+        resetButton.setAttribute('aria-label', 'Click again to confirm reset');
+        if (!resetButton.hasAttribute('aria-live')) {
+            resetButton.setAttribute('aria-live', 'polite');
+        }
+
+        // Revert back after 3 seconds if not confirmed
+        resetConfirmTimeout = setTimeout(() => {
+            resetButton.dataset.confirming = 'false';
+            resetButton.innerHTML = resetButton.dataset.originalHtml;
+            if (hasOriginalAriaLabel) {
+                resetButton.setAttribute('aria-label', resetButton.dataset.originalAriaLabel);
+            } else {
+                resetButton.removeAttribute('aria-label');
+            }
+        }, 3000);
+    }
+}
+
 // Spacebar shortcut for spinning
 document.addEventListener('keydown', (e) => {
     // Only trigger if spacebar is pressed
@@ -883,7 +933,7 @@ document.addEventListener('keydown', (e) => {
     }
 });
 
-resetButton.addEventListener('click', resetGame);
+resetButton.addEventListener('click', handleResetClick);
 cardCountSelect.addEventListener('change', handleCardCountChange);
 customCardCountInput.addEventListener('change', resetGame);
 markSelectedBtn.addEventListener('click', markSelectedCardAsDrawn);


### PR DESCRIPTION
💡 **What**
Added a 2-step inline confirmation to the "Reset" button. When clicked once, it updates its text to "⚠️ Confirm Reset?" and waits 3 seconds. Clicking it again within that timeframe triggers the reset.

🎯 **Why**
Resetting the game clears the card history and game state completely. Users might accidentally click this button, resulting in data loss. Native browser `confirm()` dialogs are jarring and interrupt the user flow, so an inline confirmation is a better UX.

📸 **Before/After**
Before: Clicking "Reset" instantly clears game state.
After: Clicking "Reset" prompts for confirmation via inline text change ("⚠️ Confirm Reset?").

♿ **Accessibility**
The new confirmation state announces itself using an `aria-live="polite"` region and updates its `aria-label` to provide clear guidance ("Click again to confirm reset") to screen reader users, maintaining keyboard accessibility and avoiding the accessibility pitfalls of native `confirm()` dialogs.

---
*PR created automatically by Jules for task [9699183743389411115](https://jules.google.com/task/9699183743389411115) started by @noerarief23*