### PR TITLE
⚡ Bolt: Eliminate redundant Canvas state changes in text loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-07-13 - Preloading Assets During Long Animation
 **Learning:** During long, CSS-driven animations or multi-second timeouts (like the 5-8 second wheel spin), you can pre-calculate the visual result using the deterministic mathematical state to fetch remote network assets ahead of time, eliminating visual pop-in when the UI is finally updated.
 **Action:** When working on animated web games with deterministic outcomes, identify the earliest moment the result can be calculated, and proactively `new Image().src` or fetch resources during the animation gap instead of waiting for the render function to fire.
+
+## 2026-07-14 - Accumulating Canvas Transforms
+**Learning:** Calling `save()` and `restore()` repeatedly inside a tight render loop (like rendering 52 pieces of text around a wheel) causes a large amount of overhead from Canvas API state stack thrashing.
+**Action:** When rendering elements along an arc or path that require incremental rotation or translation, apply the transform cumulatively inside the loop and wrap the entire loop in a single `save()` and `restore()` block instead.

--- a/script.js
+++ b/script.js
@@ -265,15 +265,17 @@ function prerenderWheel() {
     offscreenCtx.shadowColor = 'rgba(0, 0, 0, 0.8)';
     offscreenCtx.shadowBlur = 4;
 
-    for (let i = 0; i < numSegments; i++) {
-        const angle = i * anglePerSegment;
+    // ⚡ Bolt: Accumulate rotation to avoid 104 save/restore calls per render
+    offscreenCtx.save();
+    offscreenCtx.rotate(anglePerSegment / 2);
 
+    for (let i = 0; i < numSegments; i++) {
         // Draw card text
-        offscreenCtx.save();
-        offscreenCtx.rotate(angle + anglePerSegment / 2);
         offscreenCtx.fillText(availableCards[i].display, radius * 0.7, 0);
-        offscreenCtx.restore();
+        offscreenCtx.rotate(anglePerSegment);
     }
+
+    offscreenCtx.restore();
 
     // Clear shadow for subsequent paths
     offscreenCtx.shadowBlur = 0;


### PR DESCRIPTION
💡 **What:** Optimized the Canvas text rendering loop in `prerenderWheel()` by removing per-segment `save()` and `restore()` calls, replacing them with a cumulative rotation strategy.

🎯 **Why:** Rendering 52 text segments inside a tight loop with redundant Canvas API state changes (save/restore) adds significant overhead and CPU thrashing during continuous wheel redraws.

📊 **Impact:** Eliminates 104 costly Canvas API state changes per full wheel redraw, reducing the main thread rendering burden, which helps prevent dropped frames during rapid canvas updates or window resizes.

🔬 **Measurement:** The wheel was tested locally by spinning it. The UI visually looks identical and functions the exact same. A Playwright script also confirmed there were no visual regressions during a full end-to-end wheel spin.

---
*PR created automatically by Jules for task [1283850422469771120](https://jules.google.com/task/1283850422469771120) started by @noerarief23*