### PR TITLE
⚡ Bolt: Batch canvas paths by color to reduce context state changes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2026-07-14 - Accumulating Canvas Transforms
 **Learning:** Calling `save()` and `restore()` repeatedly inside a tight render loop (like rendering 52 pieces of text around a wheel) causes a large amount of overhead from Canvas API state stack thrashing.
 **Action:** When rendering elements along an arc or path that require incremental rotation or translation, apply the transform cumulatively inside the loop and wrap the entire loop in a single `save()` and `restore()` block instead.
+## 2026-07-15 - Grouping Canvas Path Rendering by Fill Color
+**Learning:** In canvas rendering, calling `ctx.fill()` and `ctx.stroke()` for every single segment (52 times in `prerenderWheel`) introduces significant overhead due to context state changes and repeated draw calls. Interleaving these drawing commands in a single segment-by-segment loop is an anti-pattern.
+**Action:** When drawing multiple shapes that share the same color or style, invert the rendering logic: iterate over the unique colors/styles first, begin a single path (`ctx.beginPath()`), loop over the data to construct all path segments matching that color, and execute a single `ctx.fill()` and `ctx.stroke()` per unique color. This dramatically reduces draw calls and state switches.

--- a/script.js
+++ b/script.js
@@ -240,19 +240,26 @@ function prerenderWheel() {
     offscreenCtx.save();
     offscreenCtx.translate(centerX, centerY);
 
-    // ⚡ Bolt: Batch render segments to minimize canvas state changes
+    // ⚡ Bolt: Batch render segments by color to minimize canvas context state changes
     offscreenCtx.strokeStyle = '#ffffff';
     offscreenCtx.lineWidth = 2;
-    for (let i = 0; i < numSegments; i++) {
-        const angle = i * anglePerSegment;
-        const colorIndex = i % segmentColors.length;
 
-        // Draw segment
-        offscreenCtx.beginPath();
-        offscreenCtx.moveTo(0, 0);
-        offscreenCtx.arc(0, 0, radius, angle, angle + anglePerSegment);
-        offscreenCtx.closePath();
+    // Use the actual number of colors needed based on current segments
+    const activeColorsCount = Math.min(segmentColors.length, numSegments);
+
+    for (let colorIndex = 0; colorIndex < activeColorsCount; colorIndex++) {
         offscreenCtx.fillStyle = segmentColors[colorIndex];
+        offscreenCtx.beginPath();
+
+        for (let i = 0; i < numSegments; i++) {
+            if (i % segmentColors.length === colorIndex) {
+                const angle = i * anglePerSegment;
+                offscreenCtx.moveTo(0, 0);
+                offscreenCtx.arc(0, 0, radius, angle, angle + anglePerSegment);
+                offscreenCtx.closePath();
+            }
+        }
+
         offscreenCtx.fill();
         offscreenCtx.stroke();
     }


### PR DESCRIPTION
💡 What: Refactored the `prerenderWheel` canvas drawing logic to group the drawing of paths by the segment's `fillStyle` color, rather than iterating through segments one-by-one.

🎯 Why: In a canvas element, changing context properties (like `fillStyle`) and executing draw commands (`fill()`, `stroke()`) are expensive operations. For a 52-segment wheel, we were unnecessarily causing 52 state changes. By batching segments by color, we reduce this to at most 13 state changes (the maximum number of unique colors).

📊 Impact: Reduces expensive Canvas API context state changes and distinct draw calls (`fill()` and `stroke()`) by approximately 75% during rendering (from 52 down to 13), increasing the rendering speed of the prerender phase.

🔬 Measurement: The change was visually tested and confirmed locally using Playwright to ensure the rendered wheel pixels are completely identical to the pre-optimization output. There are no visual regressions.

---
*PR created automatically by Jules for task [11779479698056222184](https://jules.google.com/task/11779479698056222184) started by @noerarief23*