### PR TITLE
🎨 Palette: [UX improvement] Enhance disabled button feedback and text contrast

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-03-24 - Inline Destructive Action Confirmation
 **Learning:** For destructive actions (like clearing game state), using non-blocking inline state changes (e.g. changing text to "Confirm?" and utilizing aria-live) prevents accidental data loss without breaking user flow or triggering intrusive native confirm() dialogs.
 **Action:** Implement similar 2-step click patterns for reset/delete actions where screen real-estate is limited and native dialogs are undesirable.
+
+## 2026-07-15 - Contextual Disabled State Feedback
+**Learning:** Found that when buttons become disabled implicitly (like the spin button when the deck empties, or the mark card buttons when nothing is selected), users are often left wondering *why* the interaction is blocked. Relying purely on a visual grayed-out state isn't enough, especially for users relying on screen readers or those unfamiliar with the app's logical constraints.
+**Action:** Always provide explicit context for disabled states. For icon-only or primary action buttons, update the button text itself (e.g., "SPIN" -> "NO CARDS") and supplement it with a `title` attribute explaining the blocked state to provide a clear, discoverable reason.

--- a/script.js
+++ b/script.js
@@ -334,6 +334,8 @@ function spin(isRetry = false) {
 
     isSpinning = true;
     spinButton.disabled = true;
+    const btnText = spinButton.querySelector('.button-text');
+    if (btnText) btnText.textContent = 'SPINNING...';
     resultCard.classList.remove('show');
     resultText.textContent = 'Spinning...';
 
@@ -422,6 +424,8 @@ function spin(isRetry = false) {
                     resultText.textContent = `Spin failed after ${MAX_RETRIES} attempts. Please try spinning again manually.`;
                     isSpinning = false;
                     spinButton.disabled = false;
+                    const btnText = spinButton.querySelector('.button-text');
+                    if (btnText) btnText.textContent = 'SPIN';
                     retryCount = 0; // Reset for next attempt
                     return;
                 }
@@ -441,7 +445,12 @@ function spin(isRetry = false) {
             // Show result
             showResult();
             isSpinning = false;
-            spinButton.disabled = false;
+            // Note: We don't enable the button here if availableCards.length === 0,
+            // updateStats() inside animate() handles the 'NO CARDS' state.
+            // However, updateStats() is called before the animation finishes.
+            // Let's call updateStats() here again to ensure the button state is correct
+            // after the spin ends.
+            updateStats();
         }
     }
 
@@ -504,6 +513,18 @@ function updateStats() {
     
     // Update the card select dropdown
     updateCardSelect();
+
+    // Update spin button state
+    const btnText = spinButton.querySelector('.button-text');
+    if (availableCards.length === 0) {
+        spinButton.disabled = true;
+        if (btnText) btnText.textContent = 'NO CARDS';
+        spinButton.title = 'Deck is empty, please reset';
+    } else if (!isSpinning) {
+        spinButton.disabled = false;
+        if (btnText) btnText.textContent = 'SPIN';
+        spinButton.removeAttribute('title');
+    }
 }
 
 // Update the card select dropdown with available cards
@@ -679,7 +700,7 @@ function resetGame() {
     
     // Reset spin state and re-enable button
     isSpinning = false;
-    spinButton.disabled = false;
+    // We let updateStats() handle enabling the button and resetting text
     
     // Redraw wheel
     needsRedraw = true;
@@ -764,7 +785,7 @@ function populateCustomDeckSelect() {
 function renderCustomDeckList() {
     customDeckList.innerHTML = '';
     if (customDeckCards.length === 0) {
-        customDeckList.innerHTML = '<span style="color: #666; font-style: italic;">No cards added yet</span>';
+        customDeckList.innerHTML = '<span style="color: #999; font-style: italic;">No cards added yet</span>';
         return;
     }
 
@@ -837,15 +858,27 @@ clearCustomDeckBtn.addEventListener('click', () => {
 // Disable buttons initially and enable on valid select
 cardSelect.addEventListener('change', () => {
     markSelectedBtn.disabled = cardSelect.value === '';
+    if (markSelectedBtn.disabled) {
+        markSelectedBtn.title = 'Select a card first';
+    } else {
+        markSelectedBtn.removeAttribute('title');
+    }
 });
 // Set initial state
 markSelectedBtn.disabled = true;
+markSelectedBtn.title = 'Select a card first';
 
 customDeckSelect.addEventListener('change', () => {
     addCustomCardBtn.disabled = customDeckSelect.value === '';
+    if (addCustomCardBtn.disabled) {
+        addCustomCardBtn.title = 'Select a card first';
+    } else {
+        addCustomCardBtn.removeAttribute('title');
+    }
 });
 // Set initial state
 addCustomCardBtn.disabled = true;
+addCustomCardBtn.title = 'Select a card first';
 
 
 // Initialize custom deck select

--- a/style.css
+++ b/style.css
@@ -369,7 +369,7 @@ main {
 }
 
 .empty-state {
-    color: #666666;
+    color: #999999;
     font-style: italic;
     text-align: center;
     padding: 20px;
@@ -472,7 +472,7 @@ main {
 footer {
     text-align: center;
     padding: 20px 0;
-    color: #666666;
+    color: #999999;
     font-size: 0.9rem;
 }
 
@@ -760,7 +760,7 @@ input:focus-visible,
 
 /* Keyboard Shortcut Hint */
 .keyboard-hint {
-    color: #666666;
+    color: #999999;
     font-size: 0.85rem;
     margin-top: 8px;
     text-align: center;


### PR DESCRIPTION
💡 **What:** 
- Improved color contrast for empty states and helper text from #666666 to #999999.
- Added dynamic `title` attributes explaining why the "Mark Selected" and "Add" custom card buttons are disabled.
- Enhanced the "Spin" button to display "SPINNING..." during animation and "NO CARDS" (with an explanatory tooltip) when the deck is empty.

🎯 **Why:** 
- To meet WCAG AA contrast guidelines for better readability on dark backgrounds.
- To prevent user frustration by explaining exactly *why* an interaction is blocked when a button is disabled, rather than relying solely on a visual grayed-out state.

📸 **Before/After:**
- Empty deck spin button Before: "SPIN" (disabled)
- Empty deck spin button After: "NO CARDS" (disabled, with "Deck is empty, please reset" tooltip)

♿ **Accessibility:**
- Increased contrast ratio for secondary text.
- Tooltips provide discoverable context for blocked interactions.

---
*PR created automatically by Jules for task [2335611398644116471](https://jules.google.com/task/2335611398644116471) started by @noerarief23*