### PR TITLE
🎨 Palette: Inline confirmation for clear deck button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2026-07-15 - Contextual Disabled State Feedback
 **Learning:** Found that when buttons become disabled implicitly (like the spin button when the deck empties, or the mark card buttons when nothing is selected), users are often left wondering *why* the interaction is blocked. Relying purely on a visual grayed-out state isn't enough, especially for users relying on screen readers or those unfamiliar with the app's logical constraints.
 **Action:** Always provide explicit context for disabled states. For icon-only or primary action buttons, update the button text itself (e.g., "SPIN" -> "NO CARDS") and supplement it with a `title` attribute explaining the blocked state to provide a clear, discoverable reason.
+## 2024-05-18 - Prevent Accidental Deletion in Custom Deck
+**Learning:** Destructive actions without confirmation (like clearing a carefully built custom deck) can lead to frustrating data loss, and the app's components need consistent protection against accidental clicks.
+**Action:** Always implement an inline confirmation pattern (or similar safety check) for destructive actions that erase user-configured state, ensuring accessibility tags are updated to announce the confirmation state to screen readers.

--- a/script.js
+++ b/script.js
@@ -792,7 +792,7 @@ function populateCustomDeckSelect() {
 function renderCustomDeckList() {
     customDeckList.innerHTML = '';
     if (customDeckCards.length === 0) {
-        customDeckList.innerHTML = '<span style="color: #999; font-style: italic;">No cards added yet</span>';
+        customDeckList.innerHTML = '<span style="color: #999; font-style: italic;">No cards added yet. Select a card above to build your custom deck.</span>';
         return;
     }
 
@@ -854,11 +854,52 @@ addCustomCardBtn.addEventListener('click', () => {
     showFeedback(addCustomCardBtn, 'Added successfully', false);
 });
 
-clearCustomDeckBtn.addEventListener('click', () => {
-    customDeckCards = [];
-    renderCustomDeckList();
-    if (cardCountSelect.value === 'custom-list') {
-        resetGame();
+let clearDeckConfirmTimeout;
+clearCustomDeckBtn.addEventListener('click', (e) => {
+    const btn = e.currentTarget;
+    if (!btn.dataset.originalHtml) {
+        btn.dataset.originalHtml = btn.innerHTML;
+    }
+    const hasOriginalAriaLabel = btn.dataset.hasOriginalAriaLabel === 'true' || btn.hasAttribute('aria-label');
+    btn.dataset.hasOriginalAriaLabel = hasOriginalAriaLabel.toString();
+
+    if (hasOriginalAriaLabel && !btn.dataset.originalAriaLabel) {
+        btn.dataset.originalAriaLabel = btn.getAttribute('aria-label');
+    }
+
+    if (btn.dataset.confirming === 'true') {
+        clearTimeout(clearDeckConfirmTimeout);
+        btn.dataset.confirming = 'false';
+        btn.innerHTML = btn.dataset.originalHtml;
+        if (hasOriginalAriaLabel) {
+            btn.setAttribute('aria-label', btn.dataset.originalAriaLabel);
+        } else {
+            btn.removeAttribute('aria-label');
+        }
+
+        customDeckCards = [];
+        renderCustomDeckList();
+        if (cardCountSelect.value === 'custom-list') {
+            resetGame();
+        }
+    } else {
+        btn.dataset.confirming = 'true';
+        btn.innerHTML = '⚠️ Confirm Clear?';
+
+        btn.setAttribute('aria-label', 'Click again to confirm clearing custom deck');
+        if (!btn.hasAttribute('aria-live')) {
+            btn.setAttribute('aria-live', 'polite');
+        }
+
+        clearDeckConfirmTimeout = setTimeout(() => {
+            btn.dataset.confirming = 'false';
+            btn.innerHTML = btn.dataset.originalHtml;
+            if (hasOriginalAriaLabel) {
+                btn.setAttribute('aria-label', btn.dataset.originalAriaLabel);
+            } else {
+                btn.removeAttribute('aria-label');
+            }
+        }, 3000);
     }
 });
 


### PR DESCRIPTION
💡 What
Added an inline confirmation state to the "Clear Deck" button in the custom deck section. Also improved the empty state message to guide the user on how to add cards.

🎯 Why
To prevent accidental data loss. Clearing a custom deck is a destructive action, and a simple misclick could erase the user's carefully selected cards. The inline confirmation provides a non-intrusive safety net. The empty state was updated because "No cards added yet" is less helpful than instructing the user to "Select a card above".

📸 Before/After
Before: Clicking "Clear Deck" immediately erased the list. Empty state read "No cards added yet".
After: Clicking "Clear Deck" changes the button text to "⚠️ Confirm Clear?". Clicking again executes the clear. Waiting 3 seconds reverts the button to normal. Empty state reads "No cards added yet. Select a card above to build your custom deck."

♿ Accessibility
The inline confirmation updates the button's `aria-label` and utilizes an `aria-live` region to ensure screen reader users are informed of the state change and understand the confirmation requirement.

---
*PR created automatically by Jules for task [3070296153271787814](https://jules.google.com/task/3070296153271787814) started by @noerarief23*