### PR TITLE
🎨 Palette: Polish spin interaction accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,11 @@
 ## 2024-05-18 - Prevent Accidental Deletion in Custom Deck
 **Learning:** Destructive actions without confirmation (like clearing a carefully built custom deck) can lead to frustrating data loss, and the app's components need consistent protection against accidental clicks.
 **Action:** Always implement an inline confirmation pattern (or similar safety check) for destructive actions that erase user-configured state, ensuring accessibility tags are updated to announce the confirmation state to screen readers.
+
+## 2026-07-20 - Managing Focus During Async States and Redundant ARIA Live Announcements
+**Learning:** Found two accessibility patterns:
+1. When a button (like "Spin") is disabled during an asynchronous action (like an animation), screen reader users can lose focus entirely if focus is left on the disabled element. Focus should be deliberately managed and returned to a logical interactive element once the action completes.
+2. When inserting content into an `aria-live` region, if an image with `alt` text is added alongside text content that says the same thing, screen readers will redundantly announce the result twice.
+**Action:**
+- Always save the `document.activeElement` before initiating an async state that disables the active element, and restore it (or provide a logical fallback) upon completion.
+- Set `alt=""` and `aria-hidden="true"` on images injected into `aria-live` regions when their meaning is already conveyed by adjacent text.

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                             <div id="resultText" class="result-text">Spin the wheel to get a card!</div>
                         </div>
 
-                        <button id="spinButton" class="spin-button">
+                        <button id="spinButton" class="spin-button" aria-keyshortcuts="Space">
                             <span class="button-text">SPIN</span>
                             <span class="button-glow"></span>
                         </button>
@@ -40,7 +40,7 @@
             <aside class="history-panel">
                 <h3>Card History</h3>
                 <div id="cardHistory" class="card-history-list">
-                    <div class="empty-state">No cards drawn yet</div>
+                    <div class="empty-state">No cards drawn yet. Spin the wheel to get started!</div>
                 </div>
                 <div class="stats">
                     <p>Remaining: <span id="remainingCount">52</span></p>

--- a/script.js
+++ b/script.js
@@ -339,6 +339,8 @@ function spin(isRetry = false) {
         retryCount = 0;
     }
 
+    const wasFocused = document.activeElement === spinButton;
+
     isSpinning = true;
     spinButton.disabled = true;
     const btnText = spinButton.querySelector('.button-text');
@@ -458,6 +460,15 @@ function spin(isRetry = false) {
             // Let's call updateStats() here again to ensure the button state is correct
             // after the spin ends.
             updateStats();
+
+            // Restore focus if the spin button was focused before the spin
+            if (wasFocused) {
+                if (!spinButton.disabled) {
+                    spinButton.focus();
+                } else {
+                    resetButton.focus(); // Fallback to reset button if deck is empty
+                }
+            }
         }
     }
 
@@ -482,7 +493,8 @@ function showResult() {
     const cardImage = document.createElement('img');
     cardImage.className = 'card-face-image';
     cardImage.src = `cards/${RANK_MAP[currentCard.rank]}_of_${SUIT_MAP[currentCard.suitName]}.svg`;
-    cardImage.alt = `${getRankName(currentCard.rank)} of ${currentCard.suitName}`;
+    cardImage.alt = ""; // Empty alt text since the aria-live text contains the same info
+    cardImage.setAttribute('aria-hidden', 'true');
     resultCard.appendChild(cardImage);
     
     resultCard.className = 'result-card';
@@ -696,7 +708,7 @@ function resetGame() {
     currentCard = null;
     
     // Clear history
-    cardHistoryDiv.innerHTML = '<div class="empty-state">No cards drawn yet</div>';
+    cardHistoryDiv.innerHTML = '<div class="empty-state">No cards drawn yet. Spin the wheel to get started!</div>';
     
     // Update stats
     updateStats();


### PR DESCRIPTION
💡 What
Added `aria-keyshortcuts="Space"` to the spin button.
Managed focus by saving the active element and restoring focus to the spin button (or reset button) after the async spin completes.
Prevented redundant screen reader announcements by setting `alt=""` and `aria-hidden="true"` on the result card image within the live region.
Updated the empty state text for clarity.

🎯 Why
When disabled, a focused element drops focus to the body. Managing focus during the async spin keeps keyboard users in the flow.
Empty alt on redundant images prevents screen readers from announcing the result twice, making the experience smoother.
Empty states without actionable next steps leave users wondering what to do.

📸 Before/After
Before: Spin button loses focus after spinning, empty state says "No cards drawn yet", result card image has redundant alt text.
After: Focus remains logical, empty state adds a CTA, and redundant screen reader output is silenced.

♿ Accessibility
Improves keyboard focus management during disabled states and reduces cognitive load by eliminating redundant `aria-live` announcements. Includes explicit `aria-keyshortcuts` documentation for assistive tech.

---
*PR created automatically by Jules for task [2224909605743333124](https://jules.google.com/task/2224909605743333124) started by @noerarief23*