### PR TITLE
⚡ Bolt: [performance improvement] Prevent canvas buffer reallocation on resize

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2026-07-17 - requestAnimationFrame Timestamp Optimization
 **Learning:** Calling `Date.now()` multiple times inside a fast-firing animation loop like `requestAnimationFrame` introduces unnecessary overhead due to system clock calls. `requestAnimationFrame` inherently passes a high-resolution timestamp as an argument to its callback.
 **Action:** Always use the `timestamp` parameter provided by the `requestAnimationFrame` callback instead of calling `Date.now()` to track elapsed time in animation loops. This eliminates redundant system calls from the hot path.
+## 2026-03-02 - Canvas Dimension Assignment Reallocation
+**Learning:** Setting `canvas.width` or `canvas.height` unconditionally—even if the dimensions have not changed—clears the drawing buffer and forces the browser to reallocate memory for the canvas. In frequently called functions like `resizeCanvas` or offscreen rendering, this leads to unnecessary memory allocations, layout thrashing, and performance spikes.
+**Action:** Always check if the new dimensions are different from the current dimensions before reassigning `canvas.width` and `canvas.height`.

--- a/script.js
+++ b/script.js
@@ -193,12 +193,15 @@ function prerenderWheel() {
     }
 
     // Match offscreen canvas to main canvas
-    offscreenCanvas.width = canvas.width;
-    offscreenCanvas.height = canvas.height;
-    
-    // Scale offscreen context
-    offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
-    offscreenCtx.scale(dpr, dpr);
+    // ⚡ Bolt: Check if dimensions changed before reassigning to avoid unnecessary buffer destruction
+    if (offscreenCanvas.width !== canvas.width || offscreenCanvas.height !== canvas.height) {
+        offscreenCanvas.width = canvas.width;
+        offscreenCanvas.height = canvas.height;
+
+        // Scale offscreen context only when resized
+        offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
+        offscreenCtx.scale(dpr, dpr);
+    }
 
     // Use LOGICAL coordinates (CSS pixels)
     const size = canvas.width / dpr;
@@ -473,7 +476,7 @@ function spin(isRetry = false) {
         }
     }
 
-    animate();
+    requestAnimationFrame(animate);
 }
 
 const RANK_MAP = {
@@ -1070,12 +1073,18 @@ function resizeCanvas() {
 
     // Set drawing buffer size for HiDPI
     const dpr = window.devicePixelRatio || 1;
-    canvas.width = size * dpr;
-    canvas.height = size * dpr;
+    const newWidth = size * dpr;
+    const newHeight = size * dpr;
     
-    // Scale context to use logical coordinates
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    ctx.scale(dpr, dpr);
+    // ⚡ Bolt: Check if dimensions changed before reassigning to avoid unnecessary buffer destruction
+    if (canvas.width !== newWidth || canvas.height !== newHeight) {
+        canvas.width = newWidth;
+        canvas.height = newHeight;
+
+        // Scale context to use logical coordinates only when resized
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.scale(dpr, dpr);
+    }
     
     // Mark for redraw
     needsRedraw = true;


### PR DESCRIPTION
### 💡 What
Optimized HTML5 canvas resizing by adding conditional checks to `resizeCanvas()` and `prerenderWheel()`. The `canvas.width` and `canvas.height` properties are now only reassigned if the new calculated dimensions are different from the current ones. The initial `animate()` call in the spin function was also deferred using `requestAnimationFrame`.

### 🎯 Why
Setting `canvas.width` or `canvas.height` unconditionally—even if the dimensions haven't changed—clears the drawing buffer and forces the browser to reallocate memory for the canvas object. In functions that are called frequently like `resizeCanvas` (which fires during window resizes and setup) or during offscreen rendering cycles, this leads to unnecessary memory allocations, layout thrashing, and CPU performance spikes.

### 📊 Impact
Eliminates O(1) buffer destruction per resize event when dimensions haven't fundamentally changed, significantly reducing memory churn and preventing frame drops during rapid window adjustments.

### 🔬 Measurement
Start the Python server, open DevTools Performance tab, and record a window resize interaction. You will observe fewer "Recalculate Style" and "Paint" spikes, and lower JS heap memory turnover. Verified via Playwright that UI visual behavior is intact during spin events.

---
*PR created automatically by Jules for task [2422632660837437715](https://jules.google.com/task/2422632660837437715) started by @noerarief23*