### PR TITLE
🎨 Palette: Contextual Disabled States for Empty Actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@
 **Action:**
 - Always save the `document.activeElement` before initiating an async state that disables the active element, and restore it (or provide a logical fallback) upon completion.
 - Set `alt=""` and `aria-hidden="true"` on images injected into `aria-live` regions when their meaning is already conveyed by adjacent text.
+
+## 2026-07-19 - Contextual Disabled States for Empty Actions
+**Learning:** Relying solely on visual grayed-out states for empty states is confusing. Explicit context should be provided using title attributes.
+**Action:** Always provide explicit disabled state context using title attributes and disable destructive actions when there is no state to act upon.

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 
                         <button id="spinButton" class="spin-button" aria-keyshortcuts="Space">
                             <span class="button-text">SPIN</span>
-                            <span class="button-glow"></span>
+                            <span class="button-glow" aria-hidden="true"></span>
                         </button>
                         <div class="keyboard-hint" aria-hidden="true">Press <kbd>Space</kbd> to spin</div>
                     </div>
@@ -88,7 +88,7 @@
 
         <!-- Reset Button -->
         <button id="resetButton" class="reset-button" aria-label="Reset game">
-            <span>↻</span> Reset
+            <span aria-hidden="true">↻</span> Reset
         </button>
 
         <footer>

--- a/script.js
+++ b/script.js
@@ -806,8 +806,13 @@ function renderCustomDeckList() {
     customDeckList.innerHTML = '';
     if (customDeckCards.length === 0) {
         customDeckList.innerHTML = '<span style="color: #999; font-style: italic;">No cards added yet. Select a card above to build your custom deck.</span>';
+        clearCustomDeckBtn.disabled = true;
+        clearCustomDeckBtn.title = 'Deck is already empty';
         return;
     }
+
+    clearCustomDeckBtn.disabled = false;
+    clearCustomDeckBtn.removeAttribute('title');
 
     const fragment = document.createDocumentFragment();
 
@@ -940,7 +945,8 @@ customDeckSelect.addEventListener('change', () => {
 // Set initial state
 addCustomCardBtn.disabled = true;
 addCustomCardBtn.title = 'Select a card first';
-
+clearCustomDeckBtn.disabled = true;
+clearCustomDeckBtn.title = 'Deck is already empty';
 
 // Initialize custom deck select
 populateCustomDeckSelect();

--- a/style.css
+++ b/style.css
@@ -460,8 +460,13 @@ main {
     gap: 8px;
 }
 
-.reset-button:hover {
+.reset-button:hover:not(:disabled) {
     background: #444444;
+}
+
+.reset-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 .reset-button span:first-child {


### PR DESCRIPTION
💡 What
Added `aria-hidden="true"` to purely decorative elements (`<span>↻</span>` in the reset button and `<span class="button-glow"></span>` in the spin button). Disabled the "Clear Deck" button when the custom deck list is empty, added an explicit disabled style for it in CSS, and provided an explicit explanation for the disabled state via the `title` attribute.

🎯 Why
Visual disabled states alone can be confusing and provide no context as to why the button isn't actionable. The "Clear Deck" button shouldn't be clickable if there's nothing to clear, and users shouldn't have to guess why. Additionally, screen readers shouldn't announce purely decorative visual elements (like a glowing span or a unicode refresh symbol used strictly for visuals).

📸 Before/After
Before: The "Clear Deck" button was fully enabled even when there were no custom cards added, which could cause confusion. Decorative span elements were exposed to screen readers.
After: The "Clear Deck" button is disabled visually and functionally when the deck is empty, with a tooltip explaining that the deck is already empty. Purely decorative elements are now hidden from screen readers.

♿ Accessibility
- Added `aria-hidden="true"` to decorative elements so screen readers skip them and focus on the meaningful button text.
- Added explicit contextual feedback for a disabled button using a `title` attribute, rather than just relying on visual styles.

---
*PR created automatically by Jules for task [10055581325913737108](https://jules.google.com/task/10055581325913737108) started by @noerarief23*