### PR TITLE
🎨 Palette: Improve keyboard focus flow and empty states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -47,3 +47,11 @@
 ## 2026-07-19 - Contextual Disabled States for Empty Actions
 **Learning:** Relying solely on visual grayed-out states for empty states is confusing. Explicit context should be provided using title attributes.
 **Action:** Always provide explicit disabled state context using title attributes and disable destructive actions when there is no state to act upon.
+
+## 2026-07-21 - Explicit Focus Restoration for Synchronous Disabled States
+**Learning:** Found an accessibility issue pattern where buttons (like "Mark Selected" and "Add" custom card) disable themselves synchronously in their click handlers, causing focus to drop to the `<body>`. The previous learning only covered async actions (like the spin animation).
+**Action:** Always capture the active element (`const wasFocused = document.activeElement === btn`) before disabling it in click handlers, and restore focus to a logical adjacent interactive element (like the associated `select` dropdown) if focus was lost.
+
+## 2026-07-21 - Disable Destructive Actions for Empty States Applied to Reset
+**Learning:** Applying the "Disable Destructive Actions for Empty States" principle, the global game "Reset" button should be disabled when the game is already in its initial state (no drawn cards).
+**Action:** Always ensure global state reset buttons are disabled with explicit context via `title` attribute when there is no state to reset.

--- a/script.js
+++ b/script.js
@@ -569,6 +569,15 @@ function updateStats() {
         if (btnText) btnText.textContent = 'SPIN';
         spinButton.removeAttribute('title');
     }
+
+    // Update reset button state
+    if (drawnCards.length === 0) {
+        resetButton.disabled = true;
+        resetButton.title = 'Game is already in initial state';
+    } else {
+        resetButton.disabled = false;
+        resetButton.removeAttribute('title');
+    }
 }
 
 // Update the card select dropdown with available cards
@@ -665,6 +674,7 @@ function showFeedback(button, message, isError = true) {
 
 // Mark selected card as drawn
 function markSelectedCardAsDrawn() {
+    const wasFocused = document.activeElement === markSelectedBtn;
     const selectedIndex = cardSelect.value;
     
     if (selectedIndex === '') {
@@ -701,6 +711,11 @@ function markSelectedCardAsDrawn() {
     
     // Show success feedback
     showFeedback(markSelectedBtn, `Marked ${card.display}`, false);
+
+    // Restore focus to select dropdown if the button became disabled
+    if (wasFocused) {
+        cardSelect.focus();
+    }
 }
 
 // Reset the game
@@ -875,6 +890,7 @@ function removeCustomCard(index) {
 }
 
 addCustomCardBtn.addEventListener('click', () => {
+    const wasFocused = document.activeElement === addCustomCardBtn;
     const selectedIndex = customDeckSelect.value;
     if (selectedIndex === '') {
         showFeedback(addCustomCardBtn, 'Select a card', true);
@@ -898,6 +914,10 @@ addCustomCardBtn.addEventListener('click', () => {
         resetGame();
     }
     showFeedback(addCustomCardBtn, 'Added successfully', false);
+
+    if (wasFocused) {
+        customDeckSelect.focus();
+    }
 });
 
 let clearDeckConfirmTimeout;


### PR DESCRIPTION
💡 What
Added focus management logic so that when buttons synchronously disable themselves (like the Add custom card or Mark selected buttons), keyboard focus is intelligently restored to the adjacent dropdown. Additionally, the main game Reset button is now disabled (with an explanatory tooltip) when the game is already in its initial state.

🎯 Why
When interactive elements disable themselves, screen reader and keyboard focus resets to the top of the page (`<body>`). Restoring focus preserves the user's flow. Disabling the reset button on empty states clarifies that there's nothing to reset, preventing confusing interactions.

📸 Before/After
Video recorded in verification script demonstrates the focus drop being correctly restored and the disabled reset button.

♿ Accessibility
Improves keyboard navigation continuity and provides clear semantic state feedback (via disabled attribute and title tooltip) for screen reader users and sighted users alike.

---
*PR created automatically by Jules for task [5828208831196496939](https://jules.google.com/task/5828208831196496939) started by @noerarief23*