### PR TITLE
🎨 Palette: [Focus management]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -47,3 +47,6 @@
 ## 2026-07-19 - Contextual Disabled States for Empty Actions
 **Learning:** Relying solely on visual grayed-out states for empty states is confusing. Explicit context should be provided using title attributes.
 **Action:** Always provide explicit disabled state context using title attributes and disable destructive actions when there is no state to act upon.
+## 2026-07-21 - Restoring Focus on Self-Disabling Elements
+**Learning:** Found an accessibility issue pattern where elements (like `markSelectedBtn`, `addCustomCardBtn`, and `clearCustomDeckBtn`) disable themselves synchronously after being clicked, or are completely removed from the DOM (like `.remove-custom-card` when it is the last item). This causes screen reader and keyboard focus to drop entirely to the `<body>`, forcing users to navigate through the entire page structure again.
+**Action:** When an interactive element disables itself synchronously or gets removed from the DOM, capture and explicitly restore focus to an adjacent logical element (like the parent dropdown `customDeckSelect` or the next available remove button) to prevent focus dropping.

--- a/script.js
+++ b/script.js
@@ -701,6 +701,9 @@ function markSelectedCardAsDrawn() {
     
     // Show success feedback
     showFeedback(markSelectedBtn, `Marked ${card.display}`, false);
+
+    // Restore focus since markSelectedBtn disables itself if nothing is selected
+    cardSelect.focus();
 }
 
 // Reset the game
@@ -872,6 +875,19 @@ function removeCustomCard(index) {
     if (cardCountSelect.value === 'custom-list') {
         resetGame();
     }
+
+    // Explicitly set focus since the button was removed from DOM
+    if (customDeckCards.length === 0) {
+        customDeckSelect.focus();
+    } else {
+        // If there are still cards, focus the next available remove button,
+        // or the previous one if we deleted the last item
+        const remainingBtns = document.querySelectorAll('.remove-custom-card');
+        if (remainingBtns.length > 0) {
+            const nextFocusIndex = Math.min(index, remainingBtns.length - 1);
+            remainingBtns[nextFocusIndex].focus();
+        }
+    }
 }
 
 addCustomCardBtn.addEventListener('click', () => {
@@ -898,6 +914,9 @@ addCustomCardBtn.addEventListener('click', () => {
         resetGame();
     }
     showFeedback(addCustomCardBtn, 'Added successfully', false);
+
+    // Restore focus since button disabled itself
+    customDeckSelect.focus();
 });
 
 let clearDeckConfirmTimeout;
@@ -928,6 +947,9 @@ clearCustomDeckBtn.addEventListener('click', (e) => {
         if (cardCountSelect.value === 'custom-list') {
             resetGame();
         }
+
+        // Restore focus since button disabled itself
+        customDeckSelect.focus();
     } else {
         btn.dataset.confirming = 'true';
         btn.innerHTML = '⚠️ Confirm Clear?';


### PR DESCRIPTION
💡 **What:** 
Added focus management to several buttons (`markSelectedBtn`, `addCustomCardBtn`, `clearCustomDeckBtn`, and `removeCustomCard`) that disable themselves or are removed from the DOM after interaction.

🎯 **Why:** 
When an interactive element disables itself synchronously or gets removed from the DOM, focus drops entirely to the document `<body>`. This forces keyboard and screen reader users to navigate from the top of the document all over again, creating a frustrating experience.

📸 **Before/After:** 
*(Visuals remain unchanged. The interaction flow is improved.)*

♿ **Accessibility:** 
By restoring focus to adjacent logical interactive elements (like the associated dropdown menu, or the next available remove button), keyboard and screen reader users maintain their context and can seamlessly continue their interactions without getting lost.

---
*PR created automatically by Jules for task [11678835638719900469](https://jules.google.com/task/11678835638719900469) started by @noerarief23*