### PR TITLE
⚡ Bolt: Prevent double-render on initialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,3 +42,6 @@
 ## 2026-02-12 - Canvas Resize Thrashing on Mobile
 **Learning:** Mobile browsers frequently trigger 'resize' events during vertical scrolling as the address bar shows/hides, even when the actual viewport width hasn't changed. If canvas redraw logic is bound directly to the 'resize' event without checking for dimension changes, this causes severe rendering thrashing and frame drops on scroll.
 **Action:** Always wrap canvas redraw operations inside 'resize' handlers with a conditional check to verify that the canvas width or height has actually changed before executing the redraw.
+## 2026-11-20 - Avoiding Double-Render on DOMContentLoaded
+**Learning:** Making immediate synchronous UI initialization calls (like rendering canvas or updating stats) on `DOMContentLoaded` if they are also handled by `requestAnimationFrame`-based layout observers (e.g., `waitForLayout`) causes a severe double-render penalty during Time-to-Interactive.
+**Action:** When using layout observers to initialize UI, avoid making identical synchronous initialization calls on `DOMContentLoaded`. Instead, let the layout observer handle the initial render to prevent redundant rendering work.

--- a/script.js
+++ b/script.js
@@ -1192,10 +1192,11 @@ function waitForLayout(callback) {
 
 document.addEventListener('DOMContentLoaded', () => {
     preloadAudio();
-    // Call resize immediately
-    resizeCanvas();
-    updateStats();
-    // Also wait for proper layout
+    // ⚡ Bolt: Removed immediate synchronous UI initialization calls (resizeCanvas, updateStats)
+    // on DOMContentLoaded to prevent a severe double-render penalty during Time-to-Interactive,
+    // as these are already handled correctly by the requestAnimationFrame-based waitForLayout observer.
+
+    // Wait for proper layout before initial render
     waitForLayout(() => {
         resizeCanvas();
         updateStats();


### PR DESCRIPTION
💡 **What:** Removed immediate synchronous calls to `resizeCanvas()` and `updateStats()` inside `DOMContentLoaded`.

🎯 **Why:** These functions were being called immediately on load, and then again immediately after via `waitForLayout()`, resulting in a redundant layout thrash and render pass before the DOM was even fully stable. Deferring entirely to the layout observer fixes this.

📊 **Impact:** Reduces main thread blocking time during initial load, preventing a double-render penalty and improving Time-to-Interactive (TTI).

🔬 **Measurement:** Verify by observing the initial page load. The UI will render exactly once when the layout becomes ready, rather than trying to size the canvas twice rapidly. Verified with local Playwright script execution that the game starts exactly as expected.

---
*PR created automatically by Jules for task [11919282999199437969](https://jules.google.com/task/11919282999199437969) started by @noerarief23*