### PR TITLE
🎨 Palette: Semantic collections & visual polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -58,3 +58,7 @@
 ## 2026-07-21 - Disable Destructive Actions for Empty States Applied to Reset
 **Learning:** Applying the "Disable Destructive Actions for Empty States" principle, the global game "Reset" button should be disabled when the game is already in its initial state (no drawn cards).
 **Action:** Always ensure global state reset buttons are disabled with explicit context via `title` attribute when there is no state to reset.
+
+## 2026-07-22 - Semantic Lists for Dynamic Collections
+**Learning:** Found an accessibility issue pattern where dynamic collections (like the card history and custom deck builder) were implemented using generic `<div>` tags instead of semantic `<ul>` and `<li>` lists. Screen readers announce list sizes and structure to users navigating with them, providing valuable context that generic `div`s lack.
+**Action:** Always use semantic `<ul>`/`<ol>` and `<li>` elements for displaying lists or dynamic collections of items, and ensure `ul`/`ol` tags include an appropriate `aria-label` attribute if they lack a visible labeling element. Update CSS to remove default browser list styling if a custom appearance is required.

--- a/index.html
+++ b/index.html
@@ -38,9 +38,9 @@
             <!-- Card History -->
             <aside class="history-panel">
                 <h3>Card History</h3>
-                <div id="cardHistory" class="card-history-list">
-                    <div class="empty-state">No cards drawn yet. Spin the wheel to get started!</div>
-                </div>
+                <ul id="cardHistory" class="card-history-list" aria-label="Card history">
+                    <li class="empty-state">No cards drawn yet. Spin the wheel to get started!</li>
+                </ul>
                 <div class="stats">
                     <p>Remaining: <span id="remainingCount">52</span></p>
                     <p>Drawn: <span id="drawnCount">0</span></p>
@@ -71,9 +71,9 @@
                     <button id="addCustomCardBtn" class="mark-button" aria-live="polite">Add</button>
                     <button id="clearCustomDeckBtn" class="reset-button" style="position: static; margin: 0; padding: 10px 15px; font-size: 0.9rem;">Clear Deck</button>
                 </div>
-                <div id="customDeckList" class="custom-deck-list">
+                <ul id="customDeckList" class="custom-deck-list" aria-label="Custom deck cards">
                     <!-- Custom cards will appear here -->
-                </div>
+                </ul>
             </div>
             <div class="config-item">
                 <label for="cardSelect">Mark cards as drawn:</label>

--- a/script.js
+++ b/script.js
@@ -614,7 +614,7 @@ function addToHistory(card) {
         return;
     }
     
-    const historyItem = document.createElement('div');
+    const historyItem = document.createElement('li');
     historyItem.className = 'history-item';
     
     const cardDisplay = document.createElement('div');
@@ -748,7 +748,7 @@ function resetGame() {
     currentCard = null;
     
     // Clear history
-    cardHistoryDiv.innerHTML = '<div class="empty-state">No cards drawn yet. Spin the wheel to get started!</div>';
+    cardHistoryDiv.innerHTML = '<li class="empty-state">No cards drawn yet. Spin the wheel to get started!</li>';
     
     // Update stats
     updateStats();
@@ -844,7 +844,7 @@ function populateCustomDeckSelect() {
 function renderCustomDeckList() {
     customDeckList.innerHTML = '';
     if (customDeckCards.length === 0) {
-        customDeckList.innerHTML = '<span style="color: #999; font-style: italic;">No cards added yet. Select a card above to build your custom deck.</span>';
+        customDeckList.innerHTML = '<li style="color: #999; font-style: italic; list-style: none;">No cards added yet. Select a card above to build your custom deck.</li>';
         if (clearCustomDeckBtn) {
             clearCustomDeckBtn.disabled = true;
             clearCustomDeckBtn.title = 'Custom deck is already empty';
@@ -860,7 +860,7 @@ function renderCustomDeckList() {
     const fragment = document.createDocumentFragment();
 
     customDeckCards.forEach((card, index) => {
-        const item = document.createElement('div');
+        const item = document.createElement('li');
         item.className = 'custom-deck-item';
 
         const cardText = document.createElement('span');

--- a/style.css
+++ b/style.css
@@ -366,6 +366,9 @@ main {
     overflow-y: auto;
     margin-bottom: 15px;
     min-height: 200px;
+    list-style: none;
+    padding: 0;
+    margin: 0 0 15px 0;
 }
 
 .empty-state {
@@ -721,6 +724,7 @@ input:focus-visible,
     border: 1px dashed #333;
     padding: 10px;
     border-radius: 4px;
+    list-style: none;
 }
 
 .custom-deck-item {
@@ -731,6 +735,10 @@ input:focus-visible,
     align-items: center;
     gap: 5px;
     font-size: 0.9em;
+}
+
+.custom-deck-item .red {
+    color: #ff4444;
 }
 
 .remove-custom-card {


### PR DESCRIPTION
### 💡 What
Updated the `cardHistory` and `customDeckList` elements to use semantic HTML `<ul>` and `<li>` tags instead of generic `<div>` and `<span>` tags. Added a minor CSS tweak so that red-suited cards in the custom deck view actually appear visually red.

### 🎯 Why
Semantic lists give screen readers essential structural context—such as the total number of items in a collection—allowing users to understand the scope and navigate more efficiently. Additionally, applying the `.red` color class to the custom deck items improves visual feedback for sighted users building their deck.

### 📸 Before/After
**Before:** Dynamic lists were injected as generic `<div>` elements without any grouping semantics, making it hard for screen reader users to discern where a list begins, ends, or how many items it contains. Heart and Diamond cards added to the custom deck were displayed in standard white text.
**After:** Lists are wrapped in `<ul>` containers with descriptive `aria-label`s, and children are injected as `<li>` elements, giving perfect structural context. Heart and Diamond cards in the custom deck now display in red (`#ff4444`). 

### ♿ Accessibility
*   **Semantic Structure:** Swapped `<div>` containers for `<ul>` and item `<div>`/`<span>`s for `<li>`.
*   **Accessible Names:** Added `aria-label="Card history"` and `aria-label="Custom deck cards"` to the new `<ul>` elements.
*   **Screen Reader Experience:** Screen reader users will now be properly announced the list structure and item counts when focusing or navigating these collections.

---
*PR created automatically by Jules for task [12916941856657021546](https://jules.google.com/task/12916941856657021546) started by @noerarief23*