### PR TITLE
🎨 Palette: Disable empty dynamic dropdown

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -62,3 +62,7 @@
 ## 2026-07-22 - Semantic Lists for Dynamic Collections
 **Learning:** Found an accessibility issue pattern where dynamic collections (like the card history and custom deck builder) were implemented using generic `<div>` tags instead of semantic `<ul>` and `<li>` lists. Screen readers announce list sizes and structure to users navigating with them, providing valuable context that generic `div`s lack.
 **Action:** Always use semantic `<ul>`/`<ol>` and `<li>` elements for displaying lists or dynamic collections of items, and ensure `ul`/`ol` tags include an appropriate `aria-label` attribute if they lack a visible labeling element. Update CSS to remove default browser list styling if a custom appearance is required.
+
+## 2023-11-20 - Disable Dynamic Empty Dropdowns
+**Learning:** Found an accessibility issue pattern where dynamic dropdown menus (like "Mark cards as drawn") remained enabled even when there were no options left to select. Users could click the dropdown only to find it confusingly empty, which is a dead-end interaction.
+**Action:** Always disable dynamic select dropdowns when their backing data is empty. When doing so, provide explicit context via a `title` attribute (e.g. 'All cards have been drawn') and update the placeholder option text (e.g. '-- No cards available --') to explain why the input is blocked and prevent user frustration.

--- a/script.js
+++ b/script.js
@@ -582,8 +582,15 @@ function updateStats() {
 
 // Update the card select dropdown with available cards
 function updateCardSelect() {
-    // Clear existing options except the first one
-    cardSelect.innerHTML = '<option value="">-- Select a card --</option>';
+    if (availableCards.length === 0) {
+        cardSelect.innerHTML = '<option value="">-- No cards available --</option>';
+        cardSelect.disabled = true;
+        cardSelect.title = 'All cards have been drawn';
+    } else {
+        cardSelect.innerHTML = '<option value="">-- Select a card --</option>';
+        cardSelect.disabled = false;
+        cardSelect.removeAttribute('title');
+    }
     
     // Use DocumentFragment for performance
     const fragment = document.createDocumentFragment();

--- a/style.css
+++ b/style.css
@@ -109,6 +109,12 @@ header {
     min-width: 200px;
 }
 
+.config-item select:disabled,
+.config-item input:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .mark-button {
     background: #333333;
     border: 1px solid #666666;


### PR DESCRIPTION
💡 What: Disabled the `cardSelect` dropdown dynamically when `availableCards.length` is 0, changing the default option text to "-- No cards available --" and setting an explanatory `title` attribute. Also added global CSS styles for disabled `select` and `input` elements to provide visual feedback.
🎯 Why: Prevents dead-end interactions where users could interact with a dropdown that has no options left to select, which can be confusing.
📸 Before/After: Before, the dropdown remained enabled even when all cards were drawn, offering an empty list of options. Now, the dropdown visibly disables itself, displays clear text, and provides a tooltip explaining why.
♿ Accessibility: Ensures that dynamic inputs correctly reflect their operable state, and provides clear, descriptive context via the `title` attribute for screen readers and sighted users when an action is unavailable.

---
*PR created automatically by Jules for task [1138008128838550495](https://jules.google.com/task/1138008128838550495) started by @noerarief23*