### PR TITLE
⚡ Bolt: optimize select rendering & duplicate update calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 ## 2026-11-20 - Avoiding Double-Render on DOMContentLoaded
 **Learning:** Making immediate synchronous UI initialization calls (like rendering canvas or updating stats) on `DOMContentLoaded` if they are also handled by `requestAnimationFrame`-based layout observers (e.g., `waitForLayout`) causes a severe double-render penalty during Time-to-Interactive.
 **Action:** When using layout observers to initialize UI, avoid making identical synchronous initialization calls on `DOMContentLoaded`. Instead, let the layout observer handle the initial render to prevent redundant rendering work.
+
+## 2024-05-18 - Optimized redundant UI rebuilding in spinwheel completion
+**Learning:** Found an edge case in the UI layout logic where the `spin()` animation completion block was redundantly calling `updateStats()` twice, triggering unnecessary DOM manipulations, alongside an inefficient use of `DocumentFragment` looping to rebuild a 52-item `<select>` element. Rebuilding DOM iteratively via JS is slower than passing concatenated string payloads directly to the browser's optimized HTML parser (`innerHTML`).
+**Action:** When updating elements that require complete replacements (like `<select>` options list), use `innerHTML` string concatenation over iterative `DocumentFragment` append loops for faster rendering overhead, and check for duplicate layout triggers at the end of state-machine transitions (e.g. at the end of `spin` requestAnimationFrame blocks).


### PR DESCRIPTION
💡 What: Replaced DocumentFragment mapping with innerHTML string concatenation when rebuilding custom card select dropdowns, and removed redundant updateStats calls at the end of the spin animation.
🎯 Why: Iteratively creating DOM nodes with DocumentFragment causes overhead for frequent redraws, and the duplicate updateStats triggers an unnecessary layout thrashing/re-render penalty at the completion of every spin.
📊 Impact: Eliminates a duplicate full-UI layout reflow at the end of every spin. Replacing DocumentFragment with innerHTML parsing reduces node creation overhead per redraw.
🔬 Measurement: Run the verification suite and manually test the spin sequence. Validate using `node --check script.js`.

---
*PR created automatically by Jules for task [15098441486887977189](https://jules.google.com/task/15098441486887977189) started by @noerarief23*