### PR TITLE
⚡ Bolt: Fix O(N^2) DOM memory leak in select dropdown

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -74,3 +74,6 @@
 ## 2026-08-09 - O(1) Lookups in Dropdown Validation
 **Learning:** In the `updateCustomDeckSelectOptions` function, checking if each card is already in the custom deck inside a loop using `Array.some` resulted in an inefficient O(N²) nested loop complexity. This can cause unnecessary layout thrashing or long frame execution times when iterating over DOM options.
 **Action:** Replaced the `Array.some` lookup inside the loop with an O(1) hash map lookup using a `Set` of the added cards' display properties before the loop. This reduces the complexity to O(N) and significantly improves performance during UI state validation.
+## 2026-08-10 - O(N^2) DOM Bloat via insertAdjacentHTML Appends
+**Learning:** Replacing a `DocumentFragment` append loop with string concatenation (`insertAdjacentHTML('beforeend', optionsHTML)`) for list updates introduces a massive O(N^2) DOM memory leak and continuous reflows if the container's previous children are never cleared.
+**Action:** Always use `element.innerHTML = newHTMLString` when fully rebuilding list items via string concatenation to ensure the previous child elements are safely destroyed before the new ones are added, completely preventing uncontrolled DOM bloat.

--- a/script.js
+++ b/script.js
@@ -618,7 +618,9 @@ function updateCardSelect() {
         optionsHTML += `<option value="${index}">${card.display} - ${getRankName(card.rank)} of ${card.suitName}</option>`;
     });
 
-    cardSelect.insertAdjacentHTML('beforeend', optionsHTML);
+    // ⚡ Bolt: Use innerHTML to fully overwrite the container contents instead of insertAdjacentHTML('beforeend').
+    // This fixes a severe O(N^2) memory leak where the remaining 52 options were appended endlessly on every UI update without clearing previous nodes.
+    cardSelect.innerHTML = optionsHTML;
 
     // Also reset button state if it was enabled
     if (markSelectedBtn) {


### PR DESCRIPTION
💡 What: Replaced `insertAdjacentHTML('beforeend', optionsHTML)` with `innerHTML = optionsHTML` when rendering the "Mark cards as drawn" dropdown options. Added inline comments explaining the fix.

🎯 Why: The previous implementation constructed the HTML string for all remaining cards but appended it to the existing `select` element without clearing it first. This resulted in O(N²) DOM memory bloat, as on every spin or state update, all 52 (or remaining) options were endlessly concatenated to the end of the list.

📊 Impact: Fixes a severe DOM leak. The dropdown will now consistently contain at most 53 elements instead of growing infinitely into thousands of nodes over a long session, preventing browser lag and excessive memory consumption.

🔬 Measurement: A Playwright script was used to verify that selecting an option and clicking "Mark Selected" correctly decreases the option count from 53 to 52, rather than accumulating duplicate options.

*Note: Documented learning in `.jules/bolt.md` about `insertAdjacentHTML` pitfalls when replacing container lists.*

---
*PR created automatically by Jules for task [9048962720337848537](https://jules.google.com/task/9048962720337848537) started by @noerarief23*