### PR TITLE
🎨 Palette: [UX improvement] Hide redundant screen reader suits

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -111,3 +111,7 @@
 ## 2024-05-18 - Managing Focus in Destructive Actions
 **Learning:** When a destructive action button (like Reset) uses inline confirmation state and then disables itself synchronously upon success, keyboard focus will drop to the document body, breaking the keyboard navigation flow.
 **Action:** Always capture `document.activeElement` before executing the destructive action. If the triggering button was focused, explicitly restore focus to the next logical interactive element (e.g., the primary action button like `spinButton`) after the action completes.
+
+## 2024-05-20 - Hide Decorative Card Suits from Screen Readers
+**Learning:** When decorative unicode suit symbols (like `♠` or `♥`) are displayed next to their full text names (like "Ace of Spades") in lists or components, screen readers will announce both consecutively, causing a confusing and redundant auditory experience (e.g., "A Spade Suit Ace of Spades").
+**Action:** Always wrap decorative unicode symbols in a `span` or `div` with `aria-hidden="true"`, ensuring only the full semantic text representation is accessible to screen readers, keeping the auditory output clean and concise.

--- a/index.html
+++ b/index.html
@@ -15,9 +15,10 @@
 
         <div class="main-content">
             <main>
+                <h1 class="sr-only">Spinwheel Playing Cards</h1>
                 <div class="wheel-section">
                     <div class="wheel-container">
-                        <div class="wheel-pointer"></div>
+                        <div class="wheel-pointer" aria-hidden="true"></div>
                         <canvas id="wheelCanvas" role="img" aria-label="Spin wheel with 52 playing cards"></canvas>
                     </div>
                     

--- a/script.js
+++ b/script.js
@@ -643,6 +643,7 @@ function addToHistory(card) {
     const cardDisplay = document.createElement('div');
     cardDisplay.className = `history-item-card ${card.color}`;
     cardDisplay.textContent = card.display;
+    cardDisplay.setAttribute('aria-hidden', 'true');
     
     const cardName = document.createElement('div');
     cardName.className = 'history-item-name';
@@ -926,7 +927,8 @@ function renderCustomDeckList() {
     customDeckCards.forEach((card, index) => {
         html += `
             <li class="custom-deck-item">
-                <span class="${card.color}">${card.display}</span>
+                <span class="${card.color}" aria-hidden="true">${card.display}</span>
+                <span class="sr-only">${getRankName(card.rank)} of ${card.suitName}</span>
                 <button class="remove-custom-card" aria-label="Remove ${getRankName(card.rank)} of ${card.suitName}" data-index="${index}">×</button>
             </li>
         `;


### PR DESCRIPTION
🎨 Palette: [UX improvement] Hide redundant screen reader suits

💡 What
Added `aria-hidden="true"` to visual card suit symbols (like `A♠`) in the Card History and Custom Deck lists, replacing them with a cleanly formatted screen-reader-only text (like "Ace of Spades"). Added a screen-reader-only `h1` to establish a document hierarchy.

🎯 Why
When decorative unicode suit symbols were displayed alongside their full text names in lists, screen readers announced both consecutively, creating a highly redundant and confusing auditory experience for visually impaired users. Missing h1 element violated WCAG requirements.

📸 Before/After
Before: Screen reader announces "A Spade Suit Ace of Spades" when focused on a drawn card.
After: Screen reader concisely announces "Ace of Spades". Document hierarchy is now valid.

♿ Accessibility
- Added `h1.sr-only` to index.html
- Hid `.wheel-pointer` with `aria-hidden="true"`
- Hid card suit symbols in lists with `aria-hidden="true"`
- Added `.sr-only` text with full semantic card names in lists

---
*PR created automatically by Jules for task [8959484863638214603](https://jules.google.com/task/8959484863638214603) started by @noerarief23*