### PR TITLE
🎨 Palette: Hide Decorative Symbols for Cleaner Screen Reading

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -111,3 +111,6 @@
 ## 2024-05-18 - Managing Focus in Destructive Actions
 **Learning:** When a destructive action button (like Reset) uses inline confirmation state and then disables itself synchronously upon success, keyboard focus will drop to the document body, breaking the keyboard navigation flow.
 **Action:** Always capture `document.activeElement` before executing the destructive action. If the triggering button was focused, explicitly restore focus to the next logical interactive element (e.g., the primary action button like `spinButton`) after the action completes.
+## 2026-08-11 - Hiding Decorative Symbols from Screen Readers
+**Learning:** Found an accessibility issue where decorative unicode suit symbols (like `♠` or `♥`) displayed next to their full text names (e.g., "A♠ Ace of Spades") in lists caused redundant and confusing announcements for screen reader users (e.g., reading "A Black Spade Suit Ace of Spades").
+**Action:** When displaying decorative unicode symbols alongside full semantic text, wrap the visual symbols in an element with `aria-hidden="true"`, and provide a visually hidden element (`.sr-only`) containing the complete, clear semantic text to ensure a concise and accurate screen reader experience.

--- a/script.js
+++ b/script.js
@@ -643,6 +643,7 @@ function addToHistory(card) {
     const cardDisplay = document.createElement('div');
     cardDisplay.className = `history-item-card ${card.color}`;
     cardDisplay.textContent = card.display;
+    cardDisplay.setAttribute('aria-hidden', 'true');
     
     const cardName = document.createElement('div');
     cardName.className = 'history-item-name';
@@ -926,7 +927,8 @@ function renderCustomDeckList() {
     customDeckCards.forEach((card, index) => {
         html += `
             <li class="custom-deck-item">
-                <span class="${card.color}">${card.display}</span>
+                <span class="${card.color}" aria-hidden="true">${card.display}</span>
+                <span class="sr-only">${getRankName(card.rank)} of ${card.suitName}</span>
                 <button class="remove-custom-card" aria-label="Remove ${getRankName(card.rank)} of ${card.suitName}" data-index="${index}">×</button>
             </li>
         `;


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to decorative unicode suit symbols in the UI history list and custom deck options, ensuring they are ignored by assistive technologies, while retaining semantic text natively readable nearby.
🎯 Why: Screen readers were redundantly reading visually decorative unicode symbols alongside their full text name, causing frustrating and long verbal readouts like "A Black Spade Suit Ace of Spades" instead of just "Ace of Spades".
📸 Before/After: Visual presentation stays identical, while screen reader readouts are refined.
♿ Accessibility: Significant improvement to screen reader (NVDA, VoiceOver) experiences navigating card history and custom deck builder components, directly fulfilling WCAG principles for semantic non-text element context.

---
*PR created automatically by Jules for task [11130329848665505055](https://jules.google.com/task/11130329848665505055) started by @noerarief23*