### PR TITLE
⚡ Bolt: Replace insertAdjacentHTML with innerHTML to prevent memory leak

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -74,3 +74,6 @@
 ## 2026-08-09 - O(1) Lookups in Dropdown Validation
 **Learning:** In the `updateCustomDeckSelectOptions` function, checking if each card is already in the custom deck inside a loop using `Array.some` resulted in an inefficient O(N²) nested loop complexity. This can cause unnecessary layout thrashing or long frame execution times when iterating over DOM options.
 **Action:** Replaced the `Array.some` lookup inside the loop with an O(1) hash map lookup using a `Set` of the added cards' display properties before the loop. This reduces the complexity to O(N) and significantly improves performance during UI state validation.
+## 2026-08-11 - Prevent DOM memory leak in dropdown updates
+**Learning:** Updating dynamic lists like dropdown options using `insertAdjacentHTML('beforeend', ...)` inside state-update functions (e.g., `updateCardSelect`) appends new elements without removing the old ones. This results in massive O(N^2) memory leaks and DOM bloat each time the state changes.
+**Action:** When updating dynamic lists or dropdowns where the entire list structure is replaced, manually clear the container first or use `element.innerHTML = newHTML` instead of `insertAdjacentHTML('beforeend', ...)`. This cleanly resets the container and prevents memory leaks.

--- a/script.js
+++ b/script.js
@@ -618,7 +618,8 @@ function updateCardSelect() {
         optionsHTML += `<option value="${index}">${card.display} - ${getRankName(card.rank)} of ${card.suitName}</option>`;
     });
 
-    cardSelect.insertAdjacentHTML('beforeend', optionsHTML);
+    // ⚡ Bolt: Use innerHTML to overwrite the container and prevent O(N^2) memory leaks
+    cardSelect.innerHTML = optionsHTML;
 
     // Also reset button state if it was enabled
     if (markSelectedBtn) {


### PR DESCRIPTION
💡 What:
Replaced the `insertAdjacentHTML('beforeend', optionsHTML)` call inside `updateCardSelect()` with a direct assignment to `innerHTML`.

🎯 Why:
The previous implementation appended new dropdown options (up to 52 elements) to the existing `<select>` on every state update without clearing the old ones first. This resulted in an O(N^2) explosion of duplicate and hidden DOM nodes every time a card was marked as drawn, consuming massive amounts of memory and layout calculation time on longer sessions. Using `innerHTML` correctly replaces the entire contents of the dropdown in one efficient operation.

📊 Impact:
Reduces DOM bloat to O(N) where N is the current number of available cards. Prevents a severe memory leak, preventing the browser tab from crashing or slowing down significantly during extended gameplay sessions.

🔬 Measurement:
1. Start the application.
2. Observe the `<select id="cardSelect">` options in DevTools.
3. Mark a card as drawn multiple times.
4. Verify that the dropdown only contains the actual remaining cards (up to 51) and does not accumulate hundreds of duplicate `option` nodes.

---
*PR created automatically by Jules for task [16238688534558571216](https://jules.google.com/task/16238688534558571216) started by @noerarief23*