### PR TITLE
⚡ Bolt: Fix DOM memory leak in updateCardSelect

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -74,3 +74,6 @@
 ## 2026-08-09 - O(1) Lookups in Dropdown Validation
 **Learning:** In the `updateCustomDeckSelectOptions` function, checking if each card is already in the custom deck inside a loop using `Array.some` resulted in an inefficient O(N²) nested loop complexity. This can cause unnecessary layout thrashing or long frame execution times when iterating over DOM options.
 **Action:** Replaced the `Array.some` lookup inside the loop with an O(1) hash map lookup using a `Set` of the added cards' display properties before the loop. This reduces the complexity to O(N) and significantly improves performance during UI state validation.
+## 2026-11-23 - DOM Memory Leak with insertAdjacentHTML on List Updates
+**Learning:** Using `insertAdjacentHTML('beforeend', ...)` to update dynamic lists (like a dropdown menu's options) without first clearing the existing contents causes an O(N²) DOM memory leak, as the options simply stack instead of replacing the old ones. This causes bloated DOM and degraded performance with repeated interactions.
+**Action:** When repeatedly updating or rebuilding entire collections inside a container (e.g. `<select>` or `<ul>`), always use `.innerHTML = newHTML` or explicitly clear the container prior to inserting new elements, rather than blindly appending with `insertAdjacentHTML`.

--- a/script.js
+++ b/script.js
@@ -618,7 +618,9 @@ function updateCardSelect() {
         optionsHTML += `<option value="${index}">${card.display} - ${getRankName(card.rank)} of ${card.suitName}</option>`;
     });
 
-    cardSelect.insertAdjacentHTML('beforeend', optionsHTML);
+    // ⚡ Bolt: Use innerHTML to completely replace options instead of insertAdjacentHTML
+    // to prevent an O(N^2) DOM memory leak from endlessly appending options on every update.
+    cardSelect.innerHTML = optionsHTML;
 
     // Also reset button state if it was enabled
     if (markSelectedBtn) {


### PR DESCRIPTION
💡 **What**: Replaced `insertAdjacentHTML('beforeend', optionsHTML)` with `innerHTML = optionsHTML` inside `updateCardSelect` and added explanatory comments.

🎯 **Why**: When the card dropdown updates its options, it was continuously appending the new options directly to the end of the existing DOM node instead of replacing them. This caused an O(N²) DOM memory leak, rendering multiple duplicate options invisible in the DOM and degrading performance over repeated state transitions. 

📊 **Impact**: Prevents continuous DOM node bloat by keeping the total number of `<option>` elements precisely at the correct count (52 or fewer) rather than growing indefinitely.

🔬 **Measurement**: Verified with Playwright automation that continuously cycling the state maintains a bounded options list in the DOM (`document.querySelectorAll('#cardSelect option').length` returns 52 rather than steadily increasing numbers).

---
*PR created automatically by Jules for task [15805794341478214763](https://jules.google.com/task/15805794341478214763) started by @noerarief23*