### PR TITLE
🎨 Palette: [UX improvement] Hide decorative symbols from screen readers to prevent double reading

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -111,3 +111,7 @@
 ## 2024-05-18 - Managing Focus in Destructive Actions
 **Learning:** When a destructive action button (like Reset) uses inline confirmation state and then disables itself synchronously upon success, keyboard focus will drop to the document body, breaking the keyboard navigation flow.
 **Action:** Always capture `document.activeElement` before executing the destructive action. If the triggering button was focused, explicitly restore focus to the next logical interactive element (e.g., the primary action button like `spinButton`) after the action completes.
+
+## 2026-08-10 - Hiding Decorative Symbols Next to Full Text
+**Learning:** Found an accessibility issue where a decorative unicode suit symbol (like `A♠`) in the card history display was read aloud by screen readers alongside its adjacent full-text name (like "Ace of Spades"). This causes a redundant and confusing double-reading experience (e.g., "A Spades Ace of Spades").
+**Action:** Always apply `aria-hidden="true"` to decorative symbols or shorthand displays when a full-text, visible alternative is immediately adjacent, to prevent double-reading by screen readers.

--- a/script.js
+++ b/script.js
@@ -643,6 +643,7 @@ function addToHistory(card) {
     const cardDisplay = document.createElement('div');
     cardDisplay.className = `history-item-card ${card.color}`;
     cardDisplay.textContent = card.display;
+    cardDisplay.setAttribute('aria-hidden', 'true');
     
     const cardName = document.createElement('div');
     cardName.className = 'history-item-name';


### PR DESCRIPTION
💡 What
Added `aria-hidden="true"` to the decorative card display element (`cardDisplay`) in the `addToHistory()` function.

🎯 Why
When a user spins the wheel and a card is added to the history, two elements are rendered adjacent to each other: a shorthand representation (like "A♠") and the full text description (like "Ace of Spades"). Because they are immediately adjacent, screen readers will read both consecutively, resulting in a confusing and redundant output (e.g., "A Spades Ace of Spades").

📸 Before/After
- Before: Screen reader output: "A Spades Ace of Spades"
- After: Screen reader output: "Ace of Spades"

♿ Accessibility
This directly addresses WCAG standards regarding redundant text and decorative elements, ensuring a much cleaner, less frustrating experience for screen reader users by removing the double-reading of the card suit.

---
*PR created automatically by Jules for task [3911524351253050759](https://jules.google.com/task/3911524351253050759) started by @noerarief23*