### PR TITLE
🎨 Palette: Improve screen reader experience for card history

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -111,3 +111,6 @@
 ## 2024-05-18 - Managing Focus in Destructive Actions
 **Learning:** When a destructive action button (like Reset) uses inline confirmation state and then disables itself synchronously upon success, keyboard focus will drop to the document body, breaking the keyboard navigation flow.
 **Action:** Always capture `document.activeElement` before executing the destructive action. If the triggering button was focused, explicitly restore focus to the next logical interactive element (e.g., the primary action button like `spinButton`) after the action completes.
+## 2026-08-13 - Redundant Screen Reader Announcements for Decorative Icons
+**Learning:** Found an accessibility issue pattern where decorative elements containing unicode symbols (like `5♥`) were being announced by screen readers alongside their fully spelled-out text equivalents (like "5 of Hearts"). This creates a redundant and annoying auditory experience (e.g. "5 hearts 5 of Hearts").
+**Action:** Always apply `aria-hidden="true"` to elements containing decorative unicode suit symbols when the full text name is already adjacent and visible in the DOM. Avoid adding an additional `.sr-only` element if the full text name is already present, to prevent double-reading by screen readers.

--- a/script.js
+++ b/script.js
@@ -643,6 +643,7 @@ function addToHistory(card) {
     const cardDisplay = document.createElement('div');
     cardDisplay.className = `history-item-card ${card.color}`;
     cardDisplay.textContent = card.display;
+    cardDisplay.setAttribute('aria-hidden', 'true');
     
     const cardName = document.createElement('div');
     cardName.className = 'history-item-name';
@@ -908,7 +909,7 @@ function renderCustomDeckList() {
     updateCustomDeckSelectOptions();
     customDeckList.innerHTML = '';
     if (customDeckCards.length === 0) {
-        customDeckList.innerHTML = '<li style="color: #999; font-style: italic; list-style: none;">No cards added yet. Select a card above to build your custom deck.</li>';
+        customDeckList.innerHTML = '<li class="empty-state">No cards added yet. Select a card above to build your custom deck.</li>';
         if (clearCustomDeckBtn) {
             clearCustomDeckBtn.disabled = true;
             clearCustomDeckBtn.title = 'Custom deck is already empty';


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to the decorative card symbol display in the history list and updated the custom deck empty state to use the existing `.empty-state` CSS class instead of inline styles.
🎯 Why: Screen readers were redundantly announcing both the decorative symbol (e.g., "5♥") and the full text name ("5 of Hearts") sequentially, creating a frustrating experience. Also, standardizing the empty state CSS improves maintainability.
📸 Before/After: Visuals remain unchanged, but screen reader output is cleaner.
♿ Accessibility: Reduces redundant auditory clutter by hiding purely decorative unicode symbols from assistive technologies when descriptive text is already present.

---
*PR created automatically by Jules for task [1649029277944432728](https://jules.google.com/task/1649029277944432728) started by @noerarief23*