### PR TITLE
⚡ Bolt: Fix O(N^2) DOM memory leak in card select dropdown

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -74,3 +74,6 @@
 ## 2026-08-09 - O(1) Lookups in Dropdown Validation
 **Learning:** In the `updateCustomDeckSelectOptions` function, checking if each card is already in the custom deck inside a loop using `Array.some` resulted in an inefficient O(N²) nested loop complexity. This can cause unnecessary layout thrashing or long frame execution times when iterating over DOM options.
 **Action:** Replaced the `Array.some` lookup inside the loop with an O(1) hash map lookup using a `Set` of the added cards' display properties before the loop. This reduces the complexity to O(N) and significantly improves performance during UI state validation.
+## 2024-05-18 - Fix DOM leak from adjacentHTML when replacing elements
+**Learning:** Using `element.insertAdjacentHTML('beforeend', newHTML)` when attempting to update dynamic lists (e.g., dropdown options) without first clearing the container causes massive O(N^2) DOM memory leaks, as the existing elements are not cleared before the new ones are appended.
+**Action:** When updating dynamic lists that need to be completely refreshed, use `element.innerHTML = newHTML` or manually clear the container first to prevent DOM bloat.

--- a/script.js
+++ b/script.js
@@ -618,7 +618,7 @@ function updateCardSelect() {
         optionsHTML += `<option value="${index}">${card.display} - ${getRankName(card.rank)} of ${card.suitName}</option>`;
     });
 
-    cardSelect.insertAdjacentHTML('beforeend', optionsHTML);
+    cardSelect.innerHTML = optionsHTML;
 
     // Also reset button state if it was enabled
     if (markSelectedBtn) {


### PR DESCRIPTION
💡 **What**: Replaced `insertAdjacentHTML('beforeend', ...)` with `innerHTML = ...` when updating the dropdown options in `updateCardSelect()`.
🎯 **Why**: Previously, `insertAdjacentHTML` appended new options without clearing the old ones, resulting in O(N^2) DOM bloat/memory leak every time the game state updated (which triggers a dropdown refresh). This fix resets the contents completely using `innerHTML`.
📊 **Impact**: Prevents exponential growth of DOM elements and associated memory leaks in the `select` element.
🔬 **Measurement**: Verified manually via node / Playwright tests to confirm the `select` element maintains exactly the expected number of children without endlessly growing.

---
*PR created automatically by Jules for task [13093183564469995459](https://jules.google.com/task/13093183564469995459) started by @noerarief23*