### PR TITLE
🎨 Palette: [UX improvement] Make full card names visible in custom deck list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -115,3 +115,7 @@
 ## 2024-05-20 - Hide Decorative Card Suits from Screen Readers
 **Learning:** When decorative unicode suit symbols (like `♠` or `♥`) are displayed next to their full text names (like "Ace of Spades") in lists or components, screen readers will announce both consecutively, causing a confusing and redundant auditory experience (e.g., "A Spade Suit Ace of Spades").
 **Action:** Always wrap decorative unicode symbols in a `span` or `div` with `aria-hidden="true"`, ensuring only the full semantic text representation is accessible to screen readers, keeping the auditory output clean and concise.
+
+## 2026-08-07 - Visible Context for Sighted Users in Lists
+**Learning:** Found a UX/a11y issue in the custom deck builder list: The full card names (e.g., "Ace of Spades") were hidden from sighted users using `.sr-only`, leaving only the symbol ("A♠"). This created a disconnect between the dropdown menu (which showed the full name) and the selected list, making it harder for users to quickly verify their selections. Sighted users benefit from clear, descriptive text just as much as screen reader users.
+**Action:** Always aim to make descriptive text visible to all users unless it creates extreme clutter. If an adjacent symbol is purely decorative, hide the symbol from screen readers (`aria-hidden="true"`) and show the text, rather than the other way around.

--- a/patch_journal.py
+++ b/patch_journal.py
@@ -1,0 +1,14 @@
+with open('.Jules/palette.md', 'r') as f:
+    content = f.read()
+
+# I will just rewrite the last entry correctly.
+# Find the start of the last entry.
+start_idx = content.rfind("## 2026-08-07")
+if start_idx != -1:
+    new_entry = """## 2026-08-07 - Visible Context for Sighted Users in Lists
+**Learning:** Found a UX/a11y issue in the custom deck builder list: The full card names (e.g., "Ace of Spades") were hidden from sighted users using `.sr-only`, leaving only the symbol ("A♠"). This created a disconnect between the dropdown menu (which showed the full name) and the selected list, making it harder for users to quickly verify their selections. Sighted users benefit from clear, descriptive text just as much as screen reader users.
+**Action:** Always aim to make descriptive text visible to all users unless it creates extreme clutter. If an adjacent symbol is purely decorative, hide the symbol from screen readers (`aria-hidden="true"`) and show the text, rather than the other way around.
+"""
+    new_content = content[:start_idx] + new_entry
+    with open('.Jules/palette.md', 'w') as f:
+        f.write(new_content)

--- a/script.js
+++ b/script.js
@@ -930,7 +930,7 @@ function renderCustomDeckList() {
         html += `
             <li class="custom-deck-item">
                 <span class="${card.color}" aria-hidden="true">${card.display}</span>
-                <span class="sr-only">${getRankName(card.rank)} of ${card.suitName}</span>
+                <span> ${getRankName(card.rank)} of ${card.suitName}</span>
                 <button class="remove-custom-card" aria-label="Remove ${getRankName(card.rank)} of ${card.suitName}" data-index="${index}">×</button>
             </li>
         `;


### PR DESCRIPTION
**💡 What:** Removed the `.sr-only` class from the full card name text (e.g., "Ace of Spades") in the custom deck list, making it visible to all users alongside the suit symbol (e.g., "A♠").

**🎯 Why:** Previously, only the short symbol ("A♠") was visible to sighted users in the custom deck list, while the full descriptive text was hidden for screen readers only. This created a disconnect between the dropdown menu (which showed the full name) and the selected list, forcing sighted users to rely on the smaller symbols to verify their selections. By making the full text visible, the interface is clearer and more consistent for everyone.

**📸 Before/After:** (See attached frontend verification video and screenshot)
*   **Before:** List items showed only the card symbol (e.g., `A♠`).
*   **After:** List items show the symbol and the full name (e.g., `A♠ Ace of Spades`).

**♿ Accessibility:** Sighted users now benefit from the same clear, descriptive text provided to screen reader users. The adjacent decorative symbol remains correctly marked with `aria-hidden="true"` to prevent redundant screen reader announcements.

---
*PR created automatically by Jules for task [4595081447200865601](https://jules.google.com/task/4595081447200865601) started by @noerarief23*