### PR TITLE
🎨 Palette: Fix semantic HTML landmarks and heading hierarchy

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -115,3 +115,7 @@
 ## 2024-05-20 - Hide Decorative Card Suits from Screen Readers
 **Learning:** When decorative unicode suit symbols (like `♠` or `♥`) are displayed next to their full text names (like "Ace of Spades") in lists or components, screen readers will announce both consecutively, causing a confusing and redundant auditory experience (e.g., "A Spade Suit Ace of Spades").
 **Action:** Always wrap decorative unicode symbols in a `span` or `div` with `aria-hidden="true"`, ensuring only the full semantic text representation is accessible to screen readers, keeping the auditory output clean and concise.
+
+## 2026-08-15 - Semantic Landmarks and Heading Hierarchy
+**Learning:** Found accessibility issue patterns where non-sequential heading levels (like jumping from `h1` directly to `h3`) and missing ARIA landmarks for functional sections (like configuration and actions) cause problems for assistive technology users navigating single-page apps. The `region` role or `aria-label` is necessary on elements containing form fields to provide context.
+**Action:** Always maintain a strict, sequential heading hierarchy (`h1` -> `h2` -> `h3`) within the document. Additionally, ensure all interactive content is wrapped in semantic landmarks (like `<section aria-label="...">` instead of just `<div>`) to allow screen readers to properly identify and jump between distinct areas of the application.

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
             </main>
             <!-- Card History -->
             <aside class="history-panel">
-                <h3>Card History</h3>
+                <h2>Card History</h2>
                 <ul id="cardHistory" class="card-history-list" aria-label="Card history">
                     <li class="empty-state">No cards drawn yet. Spin the wheel to get started!</li>
                 </ul>
@@ -50,7 +50,7 @@
         </div>
 
         <!-- Config Panel -->
-        <div class="config-panel">
+        <section class="config-panel" aria-label="Game Configuration">
             <div class="config-item">
                 <label for="cardCount">Cards to draw:</label>
                 <select id="cardCount">
@@ -84,12 +84,14 @@
                 <button id="markSelectedBtn" class="mark-button" aria-label="Mark selected card as drawn" aria-live="polite">Mark Selected</button>
                 <span id="cardSelectHelp" class="sr-only">Select a card from the dropdown to mark as drawn</span>
             </div>
-        </div>
+        </section>
 
         <!-- Reset Button -->
-        <button id="resetButton" class="reset-button" aria-label="Reset game">
-            <span aria-hidden="true">↻</span> Reset
-        </button>
+        <section aria-label="Game Actions">
+            <button id="resetButton" class="reset-button" aria-label="Reset game">
+                <span aria-hidden="true">↻</span> Reset
+            </button>
+        </section>
 
         <footer>
             <p>&copy; 2026 Spinwheel Playing Cards - ODIN</p>

--- a/style.css
+++ b/style.css
@@ -360,7 +360,7 @@ main {
     flex-direction: column;
 }
 
-.history-panel h3 {
+.history-panel h2 {
     color: #ffffff;
     text-align: center;
     margin-bottom: 15px;


### PR DESCRIPTION
💡 **What:** 
- Updated `index.html` to replace the out-of-sequence `<h3>Card History</h3>` with a proper `<h2>Card History</h2>`.
- Wrapped the configuration panel and the reset button in semantic `<section>` landmarks with descriptive `aria-label`s.
- Updated `style.css` to ensure the history panel heading retains its exact visual styling.

🎯 **Why:** 
To comply with WCAG standards and fix two major Axe accessibility violations (`heading-order` and `region`). When heading levels jump from `h1` to `h3`, or when form controls and buttons are placed outside of defined ARIA landmarks, users relying on screen readers or other assistive technologies lose structural context and the ability to navigate the document logically.

📸 **Before/After:** 
Visually identical. Structurally, the accessibility tree now has proper, continuous heading navigation and well-defined regions for "Game Configuration" and "Game Actions".

♿ **Accessibility:** 
- Fixed WCAG 1.3.1 (Info and Relationships) by ensuring sequential heading order.
- Fixed WCAG 1.3.1 and 2.4.1 (Bypass Blocks) by ensuring all page content is contained by landmarks, allowing quick navigation between functional zones.

---
*PR created automatically by Jules for task [4297391977379932665](https://jules.google.com/task/4297391977379932665) started by @noerarief23*