### PR TITLE
🎨 Palette: Add tooltip to icon-only remove card button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -136,3 +136,7 @@
 ## 2026-08-16 - Spatial Visualization of Abstract Constraints
 **Learning:** Found an opportunity to improve the UX around abstract limits, like the number of cards drawn from a deck. Users typically have to read text (e.g. "Drawn: 5 / Remaining: 47") to understand their progress. This creates minor cognitive load. Visualizing this limit spatially makes the state of the system immediately obvious at a glance.
 **Action:** When users are operating within a bounded limit (like drawing from a fixed pool of items), introduce spatial visualizations (like a progress bar) to complement textual representations. Always ensure these visual elements include appropriate ARIA roles (e.g. `role="progressbar"`) and properties (e.g. `aria-valuenow`, `aria-valuemin`, `aria-valuemax`) so that assistive technologies can also convey this semantic information.
+
+## 2026-08-17 - Contextual Tooltips for Icon-Only Actions
+**Learning:** Found an accessibility/UX issue where icon-only buttons (like the `×` button for removing custom cards) had `aria-label` attributes for screen readers, but lacked `title` attributes. This meant sighted mouse users had no way to receive a tooltip explaining the action before clicking, which creates ambiguity.
+**Action:** Always provide explicit native tooltips using the `title` attribute for icon-only action buttons (e.g., `title="Remove card"`), ensuring parity between the visual tooltip and the screen reader `aria-label`.

--- a/script.js
+++ b/script.js
@@ -955,7 +955,7 @@ function renderCustomDeckList() {
             <li class="custom-deck-item">
                 <span class="${card.color}" aria-hidden="true">${card.display}</span>
                 <span> ${getRankName(card.rank)} of ${card.suitName}</span>
-                <button class="remove-custom-card" aria-label="Remove ${getRankName(card.rank)} of ${card.suitName}" data-index="${index}">×</button>
+                <button class="remove-custom-card" aria-label="Remove ${getRankName(card.rank)} of ${card.suitName}" title="Remove ${getRankName(card.rank)} of ${card.suitName}" data-index="${index}">×</button>
             </li>
         `;
     });


### PR DESCRIPTION
### 💡 What
Added a native browser tooltip (`title` attribute) to the "remove" button (`×`) on custom deck items.

### 🎯 Why
While the button was accessible to screen readers via `aria-label`, sighted mouse users had no visual indication of what the "×" button did until they clicked it. Adding a `title` attribute provides a helpful tooltip on hover, clarifying the destructive action ("Remove [Card Name]").

### 📸 Before/After
**Before:** Hovering over the `×` button showed no tooltip.
**After:** Hovering over the `×` button displays a tooltip like "Remove Ace of Spades".

### ♿ Accessibility
Improved parity between assistive technologies and visual users by ensuring both `aria-label` (for screen readers) and `title` (for mouse hover) are present on the icon-only action button.

---
*PR created automatically by Jules for task [14513005002782852156](https://jules.google.com/task/14513005002782852156) started by @noerarief23*