### PR TITLE
⚡ Bolt: Cache innerHTML to avoid O(N) DOM serialization overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -96,3 +96,7 @@
 ## 2026-11-25 - Prevent Garbage Collection Spikes during Result Rendering
 **Learning:** During rapid state-machine transitions like the end of a spin animation, completely destroying a DOM node via `innerHTML = ''` and immediately re-allocating a new identical tag (like an `<img>`) via `document.createElement` causes unnecessary CPU spikes due to garbage collection processing. Similarly, looping multiple `document.createElement` calls to build list items is significantly slower than parsing raw HTML strings.
 **Action:** When updating a predictable UI component (like the result card image), reuse the existing DOM node by modifying its properties instead of destroying and recreating it. For constructing new distinct elements like history list items, use string concatenation with `insertAdjacentHTML` to avoid JS-C++ API boundaries and DOM memory overhead.
+
+## 2024-05-18 - Avoid DOM Serialization Overhead
+**Learning:** Checking equality of `.innerHTML` against a string forces the browser to serialize the DOM subtree via C++, creating significant O(N) serialization overhead, which can cause CPU spikes in frequently called state-update functions.
+**Action:** To avoid this, cache the assigned string in a custom JS property (e.g., `element._lastHTML`) and use it for O(1) equality checks instead of reading from `.innerHTML`.

--- a/script.js
+++ b/script.js
@@ -644,8 +644,12 @@ function updateCardSelect() {
 
     // ⚡ Bolt: Use innerHTML to fully overwrite the container contents instead of insertAdjacentHTML('beforeend').
     // This fixes a severe O(N^2) memory leak where the remaining 52 options were appended endlessly on every UI update without clearing previous nodes.
-    if (cardSelect.innerHTML !== optionsHTML) {
+    // ⚡ Bolt: Checking equality of `.innerHTML` against a string forces the browser to serialize the DOM subtree via C++,
+    // creating significant O(N) serialization overhead. To avoid this, cache the assigned string in a custom JS property
+    // (`_lastHTML`) and use it for O(1) equality checks instead.
+    if (cardSelect._lastHTML !== optionsHTML) {
         cardSelect.innerHTML = optionsHTML;
+        cardSelect._lastHTML = optionsHTML;
     }
 
     // Also reset button state if it was enabled


### PR DESCRIPTION
### 💡 What
Replaced the `.innerHTML !== string` condition inside the `updateCardSelect` function with a custom property cache (`_lastHTML`). The assigned string is now cached and used for O(1) equality checks instead of reading from `.innerHTML`.

### 🎯 Why
Checking equality against `.innerHTML` forces the browser to serialize the DOM subtree via C++ back into a string, which introduces significant O(N) overhead. When updating dropdowns rapidly during game states, this causes unnecessary garbage collection and main thread blockages.

### 📊 Impact
Eliminates O(N) DOM string serialization when checking if dropdowns need updating, replacing it with an instant O(1) JavaScript string comparison. This stabilizes CPU usage and prevents jank during multi-state transitions.

### 🔬 Measurement
Verified functionality by rendering the dropdown and executing a card selection visually using Playwright, confirming no regressions. The performance impact can be validated by measuring Time-to-Interactive with multiple Rapid UI refreshes via the performance tab profiling tool.

---
*PR created automatically by Jules for task [886654597255866880](https://jules.google.com/task/886654597255866880) started by @noerarief23*