### PR TITLE
⚡ Bolt: [Performance] Avoid O(N) DOM serialization overhead during dropdown rebuilds

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -96,3 +96,7 @@
 ## 2026-11-25 - Prevent Garbage Collection Spikes during Result Rendering
 **Learning:** During rapid state-machine transitions like the end of a spin animation, completely destroying a DOM node via `innerHTML = ''` and immediately re-allocating a new identical tag (like an `<img>`) via `document.createElement` causes unnecessary CPU spikes due to garbage collection processing. Similarly, looping multiple `document.createElement` calls to build list items is significantly slower than parsing raw HTML strings.
 **Action:** When updating a predictable UI component (like the result card image), reuse the existing DOM node by modifying its properties instead of destroying and recreating it. For constructing new distinct elements like history list items, use string concatenation with `insertAdjacentHTML` to avoid JS-C++ API boundaries and DOM memory overhead.
+
+## 2026-11-25 - Avoid O(N) DOM Serialization on innerHTML Equality Checks
+**Learning:** Checking the equality of `.innerHTML` against a string forces the browser to serialize the DOM subtree via C++, creating significant O(N) serialization overhead, which can cause CPU spikes during frequent UI updates.
+**Action:** When conditionally replacing `.innerHTML`, cache the assigned string in a custom JS property (e.g., `element._lastHTML`) and use it for O(1) equality checks instead of directly reading `.innerHTML`.

--- a/script.js
+++ b/script.js
@@ -644,8 +644,10 @@ function updateCardSelect() {
 
     // ⚡ Bolt: Use innerHTML to fully overwrite the container contents instead of insertAdjacentHTML('beforeend').
     // This fixes a severe O(N^2) memory leak where the remaining 52 options were appended endlessly on every UI update without clearing previous nodes.
-    if (cardSelect.innerHTML !== optionsHTML) {
+    // Also use a custom property (_lastHTML) for O(1) equality check to avoid O(N) DOM serialization via C++ bindings.
+    if (cardSelect._lastHTML !== optionsHTML) {
         cardSelect.innerHTML = optionsHTML;
+        cardSelect._lastHTML = optionsHTML;
     }
 
     // Also reset button state if it was enabled


### PR DESCRIPTION
💡 What:
Replaced the `innerHTML` equality check with an O(1) custom property lookup (`_lastHTML`) inside `updateCardSelect()`.

🎯 Why:
Reading `element.innerHTML` forces the browser's C++ rendering engine to perform a full DOM subtree traversal and serialization into a string before comparison. In the `updateCardSelect` function, this check runs frequently and causes noticeable CPU spikes when evaluating the massive dropdown options string for equality.

📊 Impact:
Reduces C++ API cross-boundary overhead to near zero by avoiding DOM serialization and using a cached JS string property for equality checks. Lowers CPU overhead during frequent UI changes (such as selecting a card).

🔬 Measurement:
Start the app, interact with the card dropdown to mark items as drawn, or spin the wheel. Observe a slight decrease in scripting and style calculation time in DevTools Performance due to the elimination of the DOM serialization block during UI reflows.

---
*PR created automatically by Jules for task [1771674100476546577](https://jules.google.com/task/1771674100476546577) started by @noerarief23*