### PR TITLE
🎨 Palette: Add explicit semantic ratio to progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 <div class="stats">
                     <p>Remaining: <span id="remainingCount">52</span></p>
                     <p>Drawn: <span id="drawnCount">0</span></p>
-                    <div class="deck-progress-container" role="progressbar" aria-label="Deck progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div class="deck-progress-container" role="progressbar" aria-label="Deck progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0 of 52">
                         <div class="deck-progress-fill" id="deckProgressFill" style="width: 0%;"></div>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -588,6 +588,7 @@ function updateStats() {
         const percentage = totalCards === 0 ? 0 : (drawnCards.length / totalCards) * 100;
         deckProgressFill.style.width = `${percentage}%`;
         deckProgressContainer.setAttribute('aria-valuenow', percentage.toFixed(0));
+        deckProgressContainer.setAttribute('aria-valuetext', `${drawnCards.length} of ${totalCards}`);
     }
 
     // Update canvas aria-label to reflect current card count


### PR DESCRIPTION
💡 What: Added the `aria-valuetext` attribute to the `deck-progress-container` and configured JavaScript to dynamically update it with the ratio of drawn cards to total cards (e.g., "1 of 52").
🎯 Why: While the progress bar conveyed the remaining state visually, the semantic string provides context and precision for screen reader users and those looking closely at abstract limits.
📸 Before/After: Before, screen readers would read out a raw percentage from `aria-valuenow`. Now, they announce a more contextual string (e.g. "1 of 52") using `aria-valuetext`.
♿ Accessibility: Improved semantic understanding of bounded constraints without altering the core visual UI layout.

---
*PR created automatically by Jules for task [429634511563165745](https://jules.google.com/task/429634511563165745) started by @noerarief23*