### PR TITLE
🎨 Palette: Add precise aria-valuetext context to progress bar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -136,3 +136,7 @@
 ## 2026-08-16 - Spatial Visualization of Abstract Constraints
 **Learning:** Found an opportunity to improve the UX around abstract limits, like the number of cards drawn from a deck. Users typically have to read text (e.g. "Drawn: 5 / Remaining: 47") to understand their progress. This creates minor cognitive load. Visualizing this limit spatially makes the state of the system immediately obvious at a glance.
 **Action:** When users are operating within a bounded limit (like drawing from a fixed pool of items), introduce spatial visualizations (like a progress bar) to complement textual representations. Always ensure these visual elements include appropriate ARIA roles (e.g. `role="progressbar"`) and properties (e.g. `aria-valuenow`, `aria-valuemin`, `aria-valuemax`) so that assistive technologies can also convey this semantic information.
+
+## 2026-08-16 - Contextual Text for Progress Bars
+**Learning:** Found a UX/a11y issue where the progress bar (`role="progressbar"`) only communicated progress to screen readers as a raw percentage via `aria-valuenow`. Abstract percentages are often less meaningful than exact ratios (e.g., "5 of 52 cards drawn") when dealing with bounded constraints like a pool of items.
+**Action:** When representing bounded constraints with progress bars, always ensure they include an appropriate `aria-valuetext` attribute in addition to `aria-valuenow` to convey the exact semantic ratio (e.g., "5 of 52") to assistive technologies.

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 <div class="stats">
                     <p>Remaining: <span id="remainingCount">52</span></p>
                     <p>Drawn: <span id="drawnCount">0</span></p>
-                    <div class="deck-progress-container" role="progressbar" aria-label="Deck progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div class="deck-progress-container" role="progressbar" aria-label="Deck progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0 of 52">
                         <div class="deck-progress-fill" id="deckProgressFill" style="width: 0%;"></div>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -588,6 +588,7 @@ function updateStats() {
         const percentage = totalCards === 0 ? 0 : (drawnCards.length / totalCards) * 100;
         deckProgressFill.style.width = `${percentage}%`;
         deckProgressContainer.setAttribute('aria-valuenow', percentage.toFixed(0));
+        deckProgressContainer.setAttribute('aria-valuetext', `${drawnCards.length} of ${totalCards}`);
     }
 
     // Update canvas aria-label to reflect current card count


### PR DESCRIPTION
**💡 What:** Added the `aria-valuetext` attribute to the deck progress bar element in `index.html` and updated it dynamically inside `updateStats()` in `script.js` to reflect the exact ratio of drawn cards.

**🎯 Why:** For abstract limits like drawing from a bounded deck of 52 cards, screen readers were previously only communicating the raw percentage via `aria-valuenow`. Conveying the exact semantic ratio provides much better context and reduces cognitive load compared to raw percentages.

**📸 Before/After:** Screen reader would read "2%". Now it reads "1 of 52". Visually identical.

**♿ Accessibility:** Improves semantic clarity for screen reader users when interacting with progress bars tied to bounded constraints by providing precise `aria-valuetext` alongside the percentage.

---
*PR created automatically by Jules for task [4281287098560209037](https://jules.google.com/task/4281287098560209037) started by @noerarief23*