### PR TITLE
⚡ Bolt: Cache innerHTML for O(1) string equality check to avoid DOM serialization overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -96,3 +96,6 @@
 ## 2026-11-25 - Prevent Garbage Collection Spikes during Result Rendering
 **Learning:** During rapid state-machine transitions like the end of a spin animation, completely destroying a DOM node via `innerHTML = ''` and immediately re-allocating a new identical tag (like an `<img>`) via `document.createElement` causes unnecessary CPU spikes due to garbage collection processing. Similarly, looping multiple `document.createElement` calls to build list items is significantly slower than parsing raw HTML strings.
 **Action:** When updating a predictable UI component (like the result card image), reuse the existing DOM node by modifying its properties instead of destroying and recreating it. For constructing new distinct elements like history list items, use string concatenation with `insertAdjacentHTML` to avoid JS-C++ API boundaries and DOM memory overhead.
+## 2024-11-26 - O(1) Lookups in innerHTML equality check
+**Learning:** Checking equality of `.innerHTML` against a string forces the browser to serialize the DOM subtree via C++, creating significant O(N) serialization overhead.
+**Action:** To avoid this overhead, cache the assigned string in a custom JS property (e.g., `element._lastHTML`) and use it for O(1) equality checks instead.

--- a/script.js
+++ b/script.js
@@ -644,8 +644,10 @@ function updateCardSelect() {
 
     // ⚡ Bolt: Use innerHTML to fully overwrite the container contents instead of insertAdjacentHTML('beforeend').
     // This fixes a severe O(N^2) memory leak where the remaining 52 options were appended endlessly on every UI update without clearing previous nodes.
-    if (cardSelect.innerHTML !== optionsHTML) {
+    // Also, checking innerHTML directly forces DOM serialization. Cache the string to do an O(1) equality check instead.
+    if (cardSelect._lastHTML !== optionsHTML) {
         cardSelect.innerHTML = optionsHTML;
+        cardSelect._lastHTML = optionsHTML;
     }
 
     // Also reset button state if it was enabled


### PR DESCRIPTION
💡 What
Replaced the direct `.innerHTML` string comparison with an O(1) equality check by caching the assigned string into a custom property (`_lastHTML`).

🎯 Why
Checking `.innerHTML` directly against a string forces the browser to serialize the internal DOM subtree via C++ into a string on every check. When rebuilding a list (like the 52-item `<select>` element), doing this continuously creates unnecessary O(N) serialization overhead and degrades Time-To-Interactive during heavy DOM updates.

📊 Impact
Eliminates O(N) C++ DOM serialization overhead whenever the dropdown validation check fires, turning the equality check into an instant O(1) Javascript string match.

🔬 Measurement
Verify by adding logging before/after the check and measuring execution time inside Chrome DevTools Profiler when the state changes. The UI will render exactly as before with no visual impact.

---
*PR created automatically by Jules for task [8334547183391935727](https://jules.google.com/task/8334547183391935727) started by @noerarief23*