### PR TITLE
🎨 Palette: Add aria-valuetext to deck progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 <div class="stats">
                     <p>Remaining: <span id="remainingCount">52</span></p>
                     <p>Drawn: <span id="drawnCount">0</span></p>
-                    <div class="deck-progress-container" role="progressbar" aria-label="Deck progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div class="deck-progress-container" role="progressbar" aria-label="Deck progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0 of 52">
                         <div class="deck-progress-fill" id="deckProgressFill" style="width: 0%;"></div>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -588,6 +588,7 @@ function updateStats() {
         const percentage = totalCards === 0 ? 0 : (drawnCards.length / totalCards) * 100;
         deckProgressFill.style.width = `${percentage}%`;
         deckProgressContainer.setAttribute('aria-valuenow', percentage.toFixed(0));
+        deckProgressContainer.setAttribute('aria-valuetext', `${drawnCards.length} of ${totalCards}`);
     }
 
     // Update canvas aria-label to reflect current card count


### PR DESCRIPTION
💡 What:
Added `aria-valuetext` to the deck progress bar. 
`index.html`: updated `.deck-progress-container` to include `aria-valuetext="0 of 52"` as initial state.
`script.js`: appended logic inside `updateStats` to update the `aria-valuetext` property relative to cards drawn over total cards.

🎯 Why:
Currently, the progress bar indicates the state through visual means and a raw percentage (`aria-valuenow`). This limits context for users relying on screen readers. Adding a semantic text representation explicitly conveys progress ("X out of Y cards drawn").

📸 Before/After:
No visual changes since it alters DOM attributes read exclusively by assistive technologies.

♿ Accessibility:
Assists users navigating with screen readers by replacing raw percentage readout from `aria-valuenow` with a clear "number out of total number" description.

---
*PR created automatically by Jules for task [889838686234644402](https://jules.google.com/task/889838686234644402) started by @noerarief23*