### PR TITLE
🎨 Palette: Add semantic ratio to deck progress bar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -136,3 +136,7 @@
 ## 2026-08-16 - Spatial Visualization of Abstract Constraints
 **Learning:** Found an opportunity to improve the UX around abstract limits, like the number of cards drawn from a deck. Users typically have to read text (e.g. "Drawn: 5 / Remaining: 47") to understand their progress. This creates minor cognitive load. Visualizing this limit spatially makes the state of the system immediately obvious at a glance.
 **Action:** When users are operating within a bounded limit (like drawing from a fixed pool of items), introduce spatial visualizations (like a progress bar) to complement textual representations. Always ensure these visual elements include appropriate ARIA roles (e.g. `role="progressbar"`) and properties (e.g. `aria-valuenow`, `aria-valuemin`, `aria-valuemax`) so that assistive technologies can also convey this semantic information.
+
+## 2026-08-23 - Providing Semantic Ratios for Progress Bars
+**Learning:** Adding a basic `role="progressbar"` with min, max, and now values (like a percentage) provides the numerical value to screen readers, but it often lacks context (e.g., reading just "25"). When progress represents a concrete ratio (like cards drawn from a deck), a percentage is less informative than the actual counts.
+**Action:** When using `role="progressbar"` to represent a bounded limit or abstract constraint, always include `aria-valuetext` to provide the exact semantic ratio (e.g., "13 of 52"). This explicitly conveys the context to assistive technologies rather than relying on raw percentages.

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 <div class="stats">
                     <p>Remaining: <span id="remainingCount">52</span></p>
                     <p>Drawn: <span id="drawnCount">0</span></p>
-                    <div class="deck-progress-container" role="progressbar" aria-label="Deck progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div class="deck-progress-container" role="progressbar" aria-label="Deck progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0 of 52">
                         <div class="deck-progress-fill" id="deckProgressFill" style="width: 0%;"></div>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -588,6 +588,7 @@ function updateStats() {
         const percentage = totalCards === 0 ? 0 : (drawnCards.length / totalCards) * 100;
         deckProgressFill.style.width = `${percentage}%`;
         deckProgressContainer.setAttribute('aria-valuenow', percentage.toFixed(0));
+        deckProgressContainer.setAttribute('aria-valuetext', `${drawnCards.length} of ${totalCards}`);
     }
 
     // Update canvas aria-label to reflect current card count


### PR DESCRIPTION
### 💡 What
Added the `aria-valuetext` attribute to the deck progress bar. It dynamically updates via JavaScript to display the current ratio of drawn cards against total cards (e.g., "13 of 52").

### 🎯 Why
When progress represents a concrete and abstract limit like cards drawn from a deck, a simple percentage (which `aria-valuenow` conveys) lacks essential context. A screen reader announcing "25" is less helpful than "13 of 52". This visualizes the state spatially and semantically.

### 📸 Before/After
- **Before:** The progress bar element only included `aria-valuenow` representing the raw percentage (e.g., `aria-valuenow="25"`).
- **After:** The progress bar element now includes `aria-valuetext` mapping the explicit count (e.g., `aria-valuenow="25" aria-valuetext="13 of 52"`), significantly improving context for assistive technology. 

### ♿ Accessibility
Improved progress bar context for screen reader users by directly mapping the concrete ratio into `aria-valuetext`. This enhancement fulfills the exact intent of providing clearer contextual state boundaries visually and via screen readers. Added a journal entry detailing this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [16626161823135685731](https://jules.google.com/task/16626161823135685731) started by @noerarief23*