### PR TITLE
🎨 Palette: [UX improvement] Add aria-valuetext to progress bar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -136,3 +136,7 @@
 ## 2026-08-16 - Spatial Visualization of Abstract Constraints
 **Learning:** Found an opportunity to improve the UX around abstract limits, like the number of cards drawn from a deck. Users typically have to read text (e.g. "Drawn: 5 / Remaining: 47") to understand their progress. This creates minor cognitive load. Visualizing this limit spatially makes the state of the system immediately obvious at a glance.
 **Action:** When users are operating within a bounded limit (like drawing from a fixed pool of items), introduce spatial visualizations (like a progress bar) to complement textual representations. Always ensure these visual elements include appropriate ARIA roles (e.g. `role="progressbar"`) and properties (e.g. `aria-valuenow`, `aria-valuemin`, `aria-valuemax`) so that assistive technologies can also convey this semantic information.
+
+## 2024-05-21 - Spatial Visualization of Abstract Constraints (aria-valuetext)
+**Learning:** When using `role="progressbar"` to visualize an abstract limit (like a pool of items), setting `aria-valuenow` (as a percentage) is insufficient. Screen readers will just announce "6 percent", which loses the semantic context of the limit (e.g., "3 of 52").
+**Action:** When creating progress bars for abstract boundaries, always include an `aria-valuetext` attribute containing the exact semantic ratio string to ensure assistive technologies receive the complete context.

--- a/script.js
+++ b/script.js
@@ -588,6 +588,7 @@ function updateStats() {
         const percentage = totalCards === 0 ? 0 : (drawnCards.length / totalCards) * 100;
         deckProgressFill.style.width = `${percentage}%`;
         deckProgressContainer.setAttribute('aria-valuenow', percentage.toFixed(0));
+        deckProgressContainer.setAttribute('aria-valuetext', `${drawnCards.length} of ${totalCards}`);
     }
 
     // Update canvas aria-label to reflect current card count


### PR DESCRIPTION
**💡 What**
Added the `aria-valuetext` attribute to the `deckProgressContainer` in the `updateStats` function. It now dynamically updates to show the exact ratio of drawn cards to total cards (e.g., "1 of 52").

**🎯 Why**
Previously, the progress bar only used `aria-valuenow`, which meant screen readers would only announce a raw percentage (e.g., "6%"). This lacked the semantic context of the underlying constraint (the deck of cards). Providing the exact ratio reduces cognitive load and provides a much more intuitive experience for assistive technology users.

**📸 Before/After**
*Before:* Screen reader reads "0" or "6" from `aria-valuenow`.
*After:* Screen reader reads "0 of 52" from `aria-valuetext`.

**♿ Accessibility**
Greatly improved the screen reader experience for the bounded constraint visualization by supplying the true semantic ratio via `aria-valuetext`.

---
*PR created automatically by Jules for task [16623621171196463436](https://jules.google.com/task/16623621171196463436) started by @noerarief23*