### PR TITLE
🎨 Palette: Add semantic aria-valuetext to deck progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 <div class="stats">
                     <p>Remaining: <span id="remainingCount">52</span></p>
                     <p>Drawn: <span id="drawnCount">0</span></p>
-                    <div class="deck-progress-container" role="progressbar" aria-label="Deck progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div class="deck-progress-container" role="progressbar" aria-label="Deck progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="0 of 52">
                         <div class="deck-progress-fill" id="deckProgressFill" style="width: 0%;"></div>
                     </div>
                 </div>

--- a/script.js
+++ b/script.js
@@ -588,6 +588,7 @@ function updateStats() {
         const percentage = totalCards === 0 ? 0 : (drawnCards.length / totalCards) * 100;
         deckProgressFill.style.width = `${percentage}%`;
         deckProgressContainer.setAttribute('aria-valuenow', percentage.toFixed(0));
+        deckProgressContainer.setAttribute('aria-valuetext', `${drawnCards.length} of ${totalCards}`);
     }
 
     // Update canvas aria-label to reflect current card count


### PR DESCRIPTION
💡 What: Added `aria-valuetext` to the deck progress bar.
🎯 Why: To provide a clear semantic text value (e.g., "5 of 52") to screen readers rather than only conveying the raw percentage via `aria-valuenow`. This adds meaningful spatial context to the bounding limits.
📸 Before/After: Before, assistive tech read the raw percentage; after, it reads a descriptive fraction like "1 of 52".
♿ Accessibility: Improved screen reader output for the deck progress bar element by explicitly setting `aria-valuetext` dynamically in JavaScript whenever the state updates.

---
*PR created automatically by Jules for task [15100492073508415696](https://jules.google.com/task/15100492073508415696) started by @noerarief23*