### PR TITLE
🎨 Palette: Add aria-valuetext to deck progress bar

### DIFF
--- a/script.js
+++ b/script.js
@@ -588,6 +588,7 @@ function updateStats() {
         const percentage = totalCards === 0 ? 0 : (drawnCards.length / totalCards) * 100;
         deckProgressFill.style.width = `${percentage}%`;
         deckProgressContainer.setAttribute('aria-valuenow', percentage.toFixed(0));
+        deckProgressContainer.setAttribute('aria-valuetext', `${drawnCards.length} of ${totalCards}`);
     }
 
     // Update canvas aria-label to reflect current card count


### PR DESCRIPTION
💡 What: Added aria-valuetext to the deck progress bar.
🎯 Why: To convey the exact semantic ratio (e.g., '1 of 52') to assistive technologies rather than just a percentage.
📸 Before/After: See screenshot.
♿ Accessibility: Improves screen reader experience by reading out the concrete ratio of cards drawn vs total.

---
*PR created automatically by Jules for task [1267567724596533639](https://jules.google.com/task/1267567724596533639) started by @noerarief23*